### PR TITLE
fix(eshop): HttpStreamSource.Read: Use min for fetch_size

### DIFF
--- a/source/shopInstall.cpp
+++ b/source/shopInstall.cpp
@@ -1312,7 +1312,7 @@ namespace shopInstStuff {
                     return 0;
                 }
 
-                const size_t fetch_size = std::max(req_size, kReadAheadSize);
+                const size_t fetch_size = std::min(req_size, kReadAheadSize);
                 m_cache.resize(fetch_size);
                 m_download.BufferDataRange(m_cache.data(), req_off, fetch_size, nullptr);
                 m_cache_start = req_off;


### PR DESCRIPTION
The bug this PR tries to fix was introduced in:
* [Added JBOD link support](https://github.com/luketanti/CyberFoil/commit/6ced75ce4c19d895ab5fe4b1dcf3beda815b3dd4)

The current code (on development branch) in `HttpStreamSource.Read()` to compute `fetch_size` is:

```c++
const size_t fetch_size = std::max(req_size, kReadAheadSize);
```

This has two problems:

1) It is never called with a value larger than 16MB (the value of `kReadAheadSize`)
The largest value it is called with is 8MB in `InstallXciHttpStream`
Because of this, the `max` will *always* resolve to 16MB

2) This causes http range errors at end of the file for files that are not exactly divisible by 16MB.
This results in the following code/error being invoked:
    ```c++
    if (rc != 0 || sizeRead != size)
    {
        THROW_FORMAT("HTTP range read failed (rc=%d)\n", rc);
    }
    ```
    Because it could not read 16MB (`sizeRead != size`)


I'm guessing the goal was to have a nice large buffer to minimize range requests.

The challenge is knowing when `req_off + req_size > file_size` because you don't (currently) have access to the file size at that point.

I did some prototyping and it and its not hard to expose the file size to the `HttpStreamSource` but:

* If you want to know the actual file size on the server, you have to do a `HEAD` request to get the `content-length` and I believe the JBOD commit actually removed code that did that, i.e `m_header.PerformRequest();` which was used to check for `accept-ranges` but could also have been used to extract the initial `content-length`.

* You could probably get a good-enough value from the `HFS0` partition.

With this change you will effectively get an 8MB buffer for all but the end of the file, which I thought may be an acceptable tradeoff for how easy the change is.

And you could probably just change the buffer size in `InstallXciHttpStream` to use `kReadAheadSize` and get both benefits:

_shopInstall.cpp:1493_
```diff
- std::vector<std::uint8_t> buf(0x800000);
+ std::vector<std::uint8_t> buf(kReadAheadSize);
```

-D

--- commit message ---

```
fix(eshop): HttpStreamSource.Read: Use min for fetch_size

Fixes fetch_size calculation to avoid range error at
end of file when file size is not an even multiple of
kReadAheadSize.
```