### PR TITLE
chore(nca_writer): Buffer writes to ContentStorage

### DIFF
--- a/include/nx/nca_writer.h
+++ b/include/nx/nca_writer.h
@@ -25,18 +25,23 @@ SOFTWARE.
 #include <vector>
 #include "nx/ncm.hpp"
 #include <memory>
-#include "install/nca.hpp"
 
 class NcaBodyWriter
 {
 public:
+	static constexpr u64 CONTENT_BUFFER_SIZE = 0x800000; // 8MB
+
 	NcaBodyWriter(const NcmContentId& ncaId, u64 offset, std::shared_ptr<nx::ncm::ContentStorage>& contentStorage);
 	virtual ~NcaBodyWriter();
+
 	virtual void write(const  u8* ptr, u64 sz);
-	
+
+	virtual void flushContentBuffer();
+
 	bool isOpen() const;
 
 protected:
+	std::vector<u8> m_contentBuffer;
 	std::shared_ptr<nx::ncm::ContentStorage> m_contentStorage;
 	NcmContentId m_ncaId;
 

--- a/source/nx/nca_writer.cpp
+++ b/source/nx/nca_writer.cpp
@@ -38,21 +38,57 @@ void append(std::vector<u8>& buffer, const u8* ptr, u64 sz)
      memcpy(buffer.data() + offset, ptr, sz);
 }
 
-NcaBodyWriter::NcaBodyWriter(const NcmContentId& ncaId, u64 offset, std::shared_ptr<nx::ncm::ContentStorage>& contentStorage) : m_contentStorage(contentStorage), m_ncaId(ncaId), m_offset(offset)
+// region NcaBodyWriter methods
+
+NcaBodyWriter::NcaBodyWriter(const NcmContentId& ncaId, u64 offset, std::shared_ptr<nx::ncm::ContentStorage>& contentStorage)
+: m_contentStorage(contentStorage), m_ncaId(ncaId), m_offset(offset)
 {
+     // Pre-allocate the memory to our buffer size to prevent reallocations/fragmentation
+     m_contentBuffer.reserve(CONTENT_BUFFER_SIZE);
 }
 
 NcaBodyWriter::~NcaBodyWriter()
 {
+     NcaBodyWriter::flushContentBuffer();
 }
 
 void NcaBodyWriter::write(const  u8* ptr, u64 sz)
 {
+     if (!sz) return; // no data
+
+     while (sz)
+     {
+          if (m_contentBuffer.size() < CONTENT_BUFFER_SIZE)
+          {
+               const u64 remainder = std::min(sz, CONTENT_BUFFER_SIZE - (u64)m_contentBuffer.size());
+               append(m_contentBuffer, ptr, remainder);
+               ptr += remainder;
+               sz -= remainder;
+          }
+
+          if (m_contentBuffer.size() < CONTENT_BUFFER_SIZE)
+          {
+               // assert sz == 0
+               return; // Need more data
+          }
+
+          // assert m_contentBuffer.size() == CONTENT_BUFFER_SIZE
+
+          flushContentBuffer();
+     }
+}
+
+void NcaBodyWriter::flushContentBuffer()
+{
+     if (m_contentBuffer.empty()) return; // No data
+
      if(isOpen())
      {
-          m_contentStorage->WritePlaceholder(*(NcmPlaceHolderId*)&m_ncaId, m_offset, (void*)ptr, sz);
-          m_offset += sz;
+          m_contentStorage->WritePlaceholder(*(NcmPlaceHolderId*)&m_ncaId, m_offset, m_contentBuffer.data(), m_contentBuffer.size());
+          m_offset += m_contentBuffer.size();
      }
+
+     m_contentBuffer.resize(0);
 }
 
 bool NcaBodyWriter::isOpen() const
@@ -60,6 +96,7 @@ bool NcaBodyWriter::isOpen() const
      return m_contentStorage != NULL;
 }
 
+// endregion
 
 class NczHeader
 {
@@ -177,24 +214,19 @@ public:
                processChunk(m_buffer.data(), m_buffer.size());
                m_buffer.clear(); // reclaim ok
           }
+          flushDeflateBuffer();
 
-          encrypt(m_deflateBuffer.data(), m_deflateBuffer.size(), m_offset);
-          flush();
+          // Ensure all data is flushed to storage
+          flushContentBuffer();
 
           return true;
      }
 
-     bool flush()
+     bool flushDeflateBuffer()
      {
-          if(!isOpen())
-          {
-               return false;
-          }
-
           if (m_deflateBuffer.size())
           {
-               m_contentStorage->WritePlaceholder(*(NcmPlaceHolderId*)&m_ncaId, m_offset, m_deflateBuffer.data(), m_deflateBuffer.size());
-               m_offset += m_deflateBuffer.size();
+               NcaBodyWriter::write(m_deflateBuffer.data(), m_deflateBuffer.size());
                m_deflateBuffer.resize(0);
           }
           return true;
@@ -275,6 +307,20 @@ public:
           return true;
      }
 
+     void flushContentBuffer() override
+     {
+          const u64 encryptOffset = m_offset;
+          const u64 encryptSize = m_contentBuffer.size();
+
+          if (encryptSize)
+          {
+               // Apply section-based encryption in-place before flushing
+               encrypt(m_contentBuffer.data(), encryptSize, encryptOffset);
+          }
+
+          NcaBodyWriter::flushContentBuffer();
+     }
+
      u64 processChunk(const u8* ptr, u64 sz)
      {
           while(sz > 0)
@@ -304,8 +350,7 @@ public:
 
                          if(m_deflateBuffer.size() >= 0x1000000)
                          {
-                              encrypt(m_deflateBuffer.data(), m_deflateBuffer.size(), m_offset);
-                              flush();
+                              flushDeflateBuffer();
                          }
 
                          p += writeChunkSz;


### PR DESCRIPTION
So as part of my continued effort to bring `NCZBLOCK` support to CyberFoil, I have another PR that moves the project closer to the solution I have my local dev.

This changes accomplishes two things:

* Centralizes Body Output buffering
  - Gives consistent behavior across input types (nca, ncz, etc)
  - Allows sub-classes to focus on data processing
  - May result in 'double-buffering' but I feel the consistent 
    write pattern to the underlying m_contentStorage is worth it
  - May result in faster game load times due to better data
    placement from longer buffer writes
    (I felt like games loaded faster in my tests)

* Decouples the Deflating and the Encrypting steps
  - Enables simplifying the logic of each step separately
  - Will be important for NCZBlock support

--- commit message ---

```
chore(nca_writer): Buffer writes to ContentStorage

* NcaBodyWriter: Adds a write buffer over m_contentStorage
  - Buffer size is configured via CONTENT_BUFFER_SIZE
    (current set at 8MB)
  - Subclasses are expected to invoke NcaBodyWriter::write()
    (even if they override it)
    and should not write to m_contentStorage directly
  - Adds flushContentBuffer() to flush data to m_contentStorage
    Can be overridden by subclasses to inspect/modify data
    before writing out

* NczBodryWriter: Routes decompressed data through the base 
  NcaBodyWriter::write()
* Overrides flushContentBuffer() to apply section-level
  encryption directly to the buffer before flushing
* Renames flush() to flushDeflateBuffer() now that
  there are multiple flush routines on the class
  
Adding the buffer at the lowest level of the Body Writing routine allows us to shift to a 'pipeline-like' process that can route data between stages as it becomes available without buffering concerns.

Anecdotally, it can also lead to faster game load times as game data has a better chance of being in consecutive blocks in storage (my testing showed notably faster load times)

Decoupling the decompression from the encryption will become important for NCZBlock handling in the future (i.e. separate stages in a pipeline)
```