### PR TITLE
Fix slow startup for large shop lists

### DIFF
--- a/source/ui/shopInstPage.cpp
+++ b/source/ui/shopInstPage.cpp
@@ -97,6 +97,19 @@ namespace {
 
     bool TryParseHexU64(const std::string& hex, std::uint64_t& out);
 
+    int ComputeListNameLimit(const std::string& suffix)
+    {
+        int nameLimit = 56;
+        if (!suffix.empty()) {
+            int maxSuffix = static_cast<int>(suffix.size()) + 1;
+            if (nameLimit > maxSuffix)
+                nameLimit -= maxSuffix;
+        }
+        if (nameLimit < 8)
+            nameLimit = 8;
+        return nameLimit;
+    }
+
     pu::ui::Color BlendOverOpaque(const pu::ui::Color& base, const pu::ui::Color& overlay)
     {
         const int a = static_cast<int>(overlay.A);
@@ -1368,22 +1381,8 @@ namespace inst::ui {
         const std::string normalizedName = OverflowText::NormalizeSingleLineText(item.name);
         std::string sizeText = FormatSizeText(item.size);
         std::string suffix = sizeText.empty() ? "" : (" [" + sizeText + "]");
-        std::string label = normalizedName + suffix;
-
-        if (this->menu == nullptr)
-            return label;
-
-        int textX = 0;
-        int maxMenuLabelWidth = 0;
-        this->getListTextBounds(textX, maxMenuLabelWidth);
-        (void)textX;
-        if (maxMenuLabelWidth <= 0)
-            return label;
-        const int maxMenuLabelHeight = this->menu->GetItemSize() - 2;
-        constexpr int kShopListMenuFontSize = 22;
-        label = ClipSingleLinePrefixSuffixByMenuRender(
-            normalizedName, suffix, kShopListMenuFontSize, maxMenuLabelWidth, maxMenuLabelHeight, nullptr);
-        return label;
+        const int nameLimit = ComputeListNameLimit(suffix);
+        return inst::util::shortenString(normalizedName, nameLimit, true) + suffix;
     }
 
     void shopInstPage::updateListMarquee(bool force)


### PR DESCRIPTION
This PR tries to fix a startup regression introduced in `1.4.2` when opening very large JSON shops in list mode.

A user reported that the same Tinfoil-style shop loaded almost instantly in `1.4.1`, but took 3-4 minutes in `1.4.2` before games appeared. (Issue #41 )

## Root cause

In `1.4.2`, shop list label fitting was changed to use the menu render path while building each row.

During startup, `drawMenuItems()` creates one menu row per visible item. On very large shops, that means thousands of calls into the label-fitting code. The new fitting path can perform multiple `RenderText()` calls per item while trying to find a one-line fit, which makes startup time scale very poorly with large catalogs.

## Fix

This PR restores the lightweight truncation path for bulk list row creation:

- use simple string shortening when building the full shop list
- avoid expensive per-item render-based fitting during initial list construction
- keep the more precise render-fit behavior in the selected-item display path where it only applies to a single item at a time

## Why this approach

The goal here is to keep the UI improvements from `1.4.2` where they are useful, without paying that cost for every item in a huge catalog before the list becomes visible.

This keeps startup behavior much closer to `1.4.1` for large JSON shops while preserving the newer display behavior for the active selection.