### PR TITLE
fix: IPC Handle Exhaustion when Installing XCI from Shop

### DIFF
--- a/include/data/buffered_placeholder_writer.hpp
+++ b/include/data/buffered_placeholder_writer.hpp
@@ -85,5 +85,7 @@ namespace tin::data
             size_t GetSizeWrittenToPlaceholder();
 
             void DebugPrintBuffers();
+
+            void close();
     };
 }

--- a/source/data/buffered_placeholder_writer.cpp
+++ b/source/data/buffered_placeholder_writer.cpp
@@ -199,6 +199,11 @@ namespace tin::data
         return m_sizeWrittenToPlaceholder;
     }
 
+    void BufferedPlaceholderWriter::close()
+    {
+        m_writer.close();
+    }
+
     void BufferedPlaceholderWriter::DebugPrintBuffers()
     {
         LOG_DEBUG("BufferedPlaceholderWriter Buffers: \n");

--- a/source/install/http_nsp.cpp
+++ b/source/install/http_nsp.cpp
@@ -277,6 +277,7 @@ namespace tin::install::nsp
 
         thrd_join(curlThread, NULL);
         thrd_join(writeThread, NULL);
+        bufferedPlaceholderWriter.close();
         if (inst::ui::instPage::isInstallCancelRequested())
             THROW_FORMAT("Installation canceled.");
         if (stopThreadsHttpNsp) THROW_FORMAT(("inst.net.transfer_interput"_lang).c_str());

--- a/source/install/usb_nsp.cpp
+++ b/source/install/usb_nsp.cpp
@@ -178,6 +178,7 @@ namespace tin::install::nsp
 
         thrd_join(usbThread, NULL);
         thrd_join(writeThread, NULL);
+        bufferedPlaceholderWriter.close();
         if (stopThreadsUsbNsp) throw std::runtime_error(errorMessageUsbNsp.c_str());
     }
 

--- a/source/install/usb_xci.cpp
+++ b/source/install/usb_xci.cpp
@@ -177,6 +177,7 @@ namespace tin::install::xci
 
         thrd_join(usbThread, NULL);
         thrd_join(writeThread, NULL);
+        bufferedPlaceholderWriter.close();
         if (stopThreadsUsbXci) throw std::runtime_error(errorMessageUsbXci.c_str());
     }
 

--- a/source/shopInstall.cpp
+++ b/source/shopInstall.cpp
@@ -1543,6 +1543,11 @@ namespace shopInstStuff {
                                     helper.CommitLatest();
                                 } catch (...) {}
                             }
+                            // Release IPC handles immediately — no longer needed after
+                            // Register/CommitLatest. Accumulating these across all NCA
+                            // entries exhausts the kernel handle table on large XCI packages.
+                            entry.nca_writer = nullptr;
+                            entry.storage = nullptr;
                         }
                     }
 


### PR DESCRIPTION
Hi!

So one of the carts I was using for all my testing over the last several PRs was Turok Trilogy XCI (personal backup), which contains 6 core nca files (3 games + 3 updates) and a bunch of others (+24 total I believe)

Installing this through the shop flow was causing system crashes.

I finally had a chance this weekend to add a bunch of debug logging and try to diagnose the issue.

Turns out the XCI HTTP installer holds onto all of the storage and writer references in its entries and doesn't free them until the install is complete.

This was leading to resource exhaustion from the OS once the count got greater than ~24.

The core of this change literally just frees the storage and writer resources as soon as it can in the flow.

The remaining change is to explicitly close the writer in the threaded install paths, which were previously just letting the default scoping/destructor logic take care of it.

This was different than all other paths which do explicitly close - Additionally, the implicit flow would not be able to catch if the writer close threw an error.

It was great to finally see the Turok Trilogy install via shop without aborting !

--- commit message ---

```
fix: IPC Handle Exhaustion when Installing XCI from Shop 

* InstallXciHttpStream:

  Release entry.storage and entry.nca_writer immediately after
  each NCA is fully written and registered.

  Previously, these were held until function return,
  accumulating excessive ContentStorage IPC sessions on large
  multi-title XCI packages.

  This risked exhausting the kernel handle table when the count
  exceeds ~24, causing an unrecoverable process abort
  mid-install.

* BufferedPlaceholderWriter:

 Add explicit close() method and call it after thread joins in
 all three threaded install paths (http_nsp, usb_nsp, usb_xci).
 
 The method explicitly closes the underlying writer.

 Without this, NCZ decompression flushes on final close() were
 triggered from the destructor, which is implicitly noexcept,
 causing std::terminate on any flush error rather than a
 catchable exception.

 NOTE: The non-threaded install paths already explicitly call
 close() on the underlying writer, so this change is just to
 bring completeness / parity to the threaded paths.
 
 Co-Authored-By: Claude (via JetBrains AI Assistant) <noreply@anthropic.com>
```