### PR TITLE
Issue 75

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ scripts
 *.sh
 *.bat
 *.a
+.codex
+tests/test_nczblock

--- a/include/nx/content_meta.hpp
+++ b/include/nx/content_meta.hpp
@@ -22,7 +22,7 @@ SOFTWARE.
 
 #pragma once
 
-#include <switch/services/ncm.h>
+#include <switch/services/ncm_types.h>
 #include <switch/types.h>
 #include <vector>
 
@@ -66,7 +66,7 @@ namespace nx::ncm
 
             PackagedContentMetaHeader GetPackagedContentMetaHeader();
             NcmContentMetaKey GetContentMetaKey();
-            std::vector<NcmContentInfo> GetContentInfos();
+            std::vector<NcmContentInfo> GetContentInfos(bool includeDeltaFragments = false);
 
             void GetInstallContentMeta(tin::data::ByteBuffer& installContentMetaBuffer, NcmContentInfo& cnmtContentInfo, bool ignoreReqFirmVersion);
     };

--- a/include/util/nczblock.hpp
+++ b/include/util/nczblock.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace tin::nczblock
+{
+    constexpr std::uint8_t kTypeZstd = 0x01;
+    constexpr std::uint32_t kZstdFrameMagic = 0xFD2FB528u;
+    constexpr std::size_t kZstdMagicSize = sizeof(kZstdFrameMagic);
+
+    enum class BlockDecodeMode
+    {
+        NeedMoreData,
+        Zstd,
+        Direct,
+        Invalid,
+    };
+
+    struct StreamValidationState
+    {
+        bool headerParsed = false;
+        bool blockSizesParsed = false;
+        std::uint32_t blockCount = 0;
+        std::uint32_t currentBlockIndex = 0;
+        bool currentBlockOpen = false;
+        std::uint64_t currentBlockReadOffset = 0;
+        std::uint64_t currentBlockCompressedSize = 0;
+        std::uint64_t totalDecompressedWritten = 0;
+        std::uint64_t expectedDecompressedSize = 0;
+    };
+
+    bool HasZstdFrameMagic(const std::vector<std::uint8_t>& prefix);
+
+    BlockDecodeMode DecideBlockDecodeMode(std::uint8_t compressionType,
+                                          std::uint64_t compressedSize,
+                                          std::uint64_t expectedDecompressedSize,
+                                          const std::vector<std::uint8_t>& prefix,
+                                          bool blockFinished);
+
+    const char* DescribeBlockDecodeMode(BlockDecodeMode mode);
+
+    bool ValidateStreamCompletion(const StreamValidationState& state, std::string& error);
+}

--- a/source/nx/content_meta.cpp
+++ b/source/nx/content_meta.cpp
@@ -23,7 +23,6 @@ SOFTWARE.
 #include "nx/content_meta.hpp"
 
 #include <string.h>
-#include "util/title_util.hpp"
 #include "util/debug.h"
 #include "util/error.hpp"
 
@@ -63,7 +62,7 @@ namespace nx::ncm
     }
 
     // TODO: Cache this
-    std::vector<NcmContentInfo> ContentMeta::GetContentInfos()
+    std::vector<NcmContentInfo> ContentMeta::GetContentInfos(bool includeDeltaFragments)
     {
         PackagedContentMetaHeader contentMetaHeader = this->GetPackagedContentMetaHeader();
 
@@ -74,8 +73,9 @@ namespace nx::ncm
         {
             PackagedContentInfo packagedContentInfo = packagedContentInfos[i];
 
-            // Don't install delta fragments. Even patches don't seem to install them.
-            if (static_cast<u8>(packagedContentInfo.content_info.content_type) <= 5)
+            // Delta fragments should not be scheduled as standalone installs, but patch
+            // metadata still needs to preserve their content records verbatim.
+            if (includeDeltaFragments || static_cast<u8>(packagedContentInfo.content_info.content_type) <= NcmContentType_LegalInformation)
             {
                 contentInfos.push_back(packagedContentInfo.content_info); 
             }
@@ -87,7 +87,11 @@ namespace nx::ncm
     void ContentMeta::GetInstallContentMeta(tin::data::ByteBuffer& installContentMetaBuffer, NcmContentInfo& cnmtNcmContentInfo, bool ignoreReqFirmVersion)
     {
         PackagedContentMetaHeader packagedContentMetaHeader = this->GetPackagedContentMetaHeader();
-        std::vector<NcmContentInfo> contentInfos = this->GetContentInfos();
+        std::vector<NcmContentInfo> contentInfos = this->GetContentInfos(true);
+        const size_t packagedContentInfosOffset = sizeof(PackagedContentMetaHeader) + packagedContentMetaHeader.extended_header_size;
+        const size_t packagedContentInfosSize = sizeof(PackagedContentInfo) * packagedContentMetaHeader.content_count;
+        const size_t packagedTailOffset = packagedContentInfosOffset + packagedContentInfosSize;
+        const size_t packagedTailSize = (m_bytes.GetSize() > packagedTailOffset) ? (m_bytes.GetSize() - packagedTailOffset) : 0;
 
         // Setup the content meta header
         NcmContentMetaHeader contentMetaHeader;
@@ -122,11 +126,11 @@ namespace nx::ncm
             installContentMetaBuffer.Append<NcmContentInfo>(contentInfo);
         }
 
-        if (packagedContentMetaHeader.type == NcmContentMetaType_Patch)
+        if (packagedTailSize > 0)
         {
-            NcmPatchMetaExtendedHeader* patchMetaExtendedHeader = (NcmPatchMetaExtendedHeader*)extendedHeaderSourceBytes;
-            installContentMetaBuffer.Resize(installContentMetaBuffer.GetSize() + patchMetaExtendedHeader->extended_data_size);
+            const size_t installTailOffset = installContentMetaBuffer.GetSize();
+            installContentMetaBuffer.Resize(installTailOffset + packagedTailSize);
+            memcpy(installContentMetaBuffer.GetData() + installTailOffset, m_bytes.GetData() + packagedTailOffset, packagedTailSize);
         }
     }
 }
-

--- a/source/nx/nca_writer.cpp
+++ b/source/nx/nca_writer.cpp
@@ -23,10 +23,12 @@ SOFTWARE.
 #include "nx/nca_writer.h"
 #include "util/error.hpp"
 #include <zstd.h>
+#include <exception>
 #include <string.h>
 #include <memory>
 #include "util/crypto.hpp"
 #include "util/config.hpp"
+#include "util/nczblock.hpp"
 #include "util/title_util.hpp"
 #include "install/nca.hpp"
 #include <limits>
@@ -411,7 +413,12 @@ class NczBlockStreamWriter : public CloseableWriter
 {
 public:
      NczBlockStreamWriter(const std::function<WriterFn>& writeFn)
-          : m_writeFn(writeFn),
+          : m_outputWriteFn(writeFn),
+            m_writeFn([this](const u8* data, u64 size)
+            {
+                 m_totalDecompressedWritten += size;
+                 m_outputWriteFn(data, size);
+            }),
             m_headerParsed(false), m_blockSizesParsed(false),
             m_currentBlockIdx(0), m_currentBlockReadOffset(0)
      {
@@ -421,20 +428,61 @@ public:
 
      ~NczBlockStreamWriter() override
      {
-          NczBlockStreamWriter::close();
+          try
+          {
+               NczBlockStreamWriter::close();
+          }
+          catch (const std::exception& e)
+          {
+               LOG_DEBUG("[NczBlockStreamWriter] close failed in destructor: %s", e.what());
+          }
+          catch (...)
+          {
+               LOG_DEBUG("[NczBlockStreamWriter] close failed in destructor with unknown exception");
+          }
      }
 
      void close() override
      {
           if (isClosed()) return; // Idempotent close
 
-          // Free resources
           if (m_currentBlockWriter)
           {
+               if (m_currentBlockReadOffset != m_currentBlockCompressedSize)
+               {
+                    THROW_FORMAT("NczBlockStreamWriter: current block ended early (%llu/%llu bytes)",
+                         static_cast<unsigned long long>(m_currentBlockReadOffset),
+                         static_cast<unsigned long long>(m_currentBlockCompressedSize));
+               }
+
                m_currentBlockWriter->close(); // Flush remaining data to writerFn
                m_currentBlockWriter = NULL;
+               m_currentBlockIdx++;
+               m_currentBlockCompressedSize = 0;
+               m_currentBlockPrefix.clear();
           }
+
+          tin::nczblock::StreamValidationState state;
+          state.headerParsed = m_headerParsed;
+          state.blockSizesParsed = m_blockSizesParsed;
+          state.blockCount = m_headerParsed ? m_header.numberOfBlocks : 0;
+          state.currentBlockIndex = static_cast<std::uint32_t>(m_currentBlockIdx);
+          state.currentBlockOpen = false;
+          state.currentBlockReadOffset = m_currentBlockReadOffset;
+          state.currentBlockCompressedSize = m_currentBlockCompressedSize;
+          state.totalDecompressedWritten = m_totalDecompressedWritten;
+          state.expectedDecompressedSize = m_headerParsed ? m_header.decompressedSize : 0;
+
+          std::string error;
+          if (!tin::nczblock::ValidateStreamCompletion(state, error))
+          {
+               THROW_FORMAT("NczBlockStreamWriter: %s", error.c_str());
+          }
+
+          // Free resources
+          m_currentBlockPrefix.clear();
           m_writeFn = NULL;
+          m_outputWriteFn = NULL;
 
           CloseableWriter::close(); // Mark as closed after all cleanups are done
      }
@@ -519,48 +567,84 @@ public:
           while (sz)
           {
                // Starting a new block?
-               if (!m_currentBlockWriter)
+               if (m_currentBlockCompressedSize == 0)
                {
                     // Out of blocks?
                     if (m_currentBlockIdx >= m_header.numberOfBlocks)
                     {
-                         return;
+                         THROW_FORMAT("NczBlockStreamWriter: received unexpected trailing block data");
                     }
 
                     m_currentBlockReadOffset = 0;
+                    m_currentBlockCompressedSize = m_blockSizes[m_currentBlockIdx];
+                    m_currentBlockPrefix.clear();
+               }
 
-                    const u64 compressedSize = m_blockSizes[m_currentBlockIdx];
+               u64 expectedDecompSize = m_header.blockSize();
+               // If last block, adjust expected decompressed to remaining
+               if (m_currentBlockIdx == m_header.numberOfBlocks - 1)
+               {
+                    const u64 remainder = m_header.decompressedSize % m_header.blockSize();
+                    if (remainder > 0) expectedDecompSize = remainder;
+               }
 
-                    u64 expectedDecompSize = m_header.blockSize();
-                    // If last block, adjust expected decompressed to remaining
-                    if (m_currentBlockIdx == m_header.numberOfBlocks - 1)
+               if (!m_currentBlockWriter)
+               {
+                    const u64 blockSize = m_currentBlockCompressedSize;
+                    const u64 remainingBeforeDecision = std::min<u64>(sz, blockSize - m_currentBlockReadOffset);
+                    const u64 prefixNeed = (m_currentBlockPrefix.size() < tin::nczblock::kZstdMagicSize)
+                         ? std::min<u64>(remainingBeforeDecision, tin::nczblock::kZstdMagicSize - m_currentBlockPrefix.size())
+                         : 0;
+
+                    if (prefixNeed > 0)
                     {
-                         const u64 remainder = m_header.decompressedSize % m_header.blockSize();
-                         if (remainder > 0) expectedDecompSize = remainder;
-                         // TODO Log if expected < compressed ?
+                         append(m_currentBlockPrefix, ptr, prefixNeed);
+                         ptr += prefixNeed;
+                         sz -= prefixNeed;
+                         m_currentBlockReadOffset += prefixNeed;
                     }
 
-                    if (m_header.usesZstd())
+                    const auto mode = tin::nczblock::DecideBlockDecodeMode(
+                         m_header.type,
+                         m_currentBlockCompressedSize,
+                         expectedDecompSize,
+                         m_currentBlockPrefix,
+                         m_currentBlockReadOffset >= m_currentBlockCompressedSize);
+
+                    switch (mode)
                     {
-                         // Even when zstd flagged, if no compression achieved, assume uncompressed
-                         if (compressedSize < expectedDecompSize)
-                         {
+                         case tin::nczblock::BlockDecodeMode::NeedMoreData:
+                              continue;
+                         case tin::nczblock::BlockDecodeMode::Zstd:
                               m_currentBlockWriter = std::make_unique<ZstdStreamWriter>(m_writeFn);
-                         }
-                         else
-                         {
-                              LOG_DEBUG("[NczBlockStreamWriter] Block (%d) appears to have no compression - Using Direct Writer", m_currentBlockIdx);
+                              break;
+                         case tin::nczblock::BlockDecodeMode::Direct:
+                              LOG_DEBUG("[NczBlockStreamWriter] Block (%d) uses direct copy", m_currentBlockIdx);
                               m_currentBlockWriter = std::make_unique<DirectStreamWriter>(m_writeFn);
-                         }
+                              break;
+                         case tin::nczblock::BlockDecodeMode::Invalid:
+                              THROW_FORMAT("NczBlockStreamWriter: invalid block encoding at block %llu (mode=%s)",
+                                   static_cast<unsigned long long>(m_currentBlockIdx),
+                                   tin::nczblock::DescribeBlockDecodeMode(mode));
                     }
-                    else
+
+                    if (!m_currentBlockPrefix.empty())
                     {
-                         LOG_DEBUG("[NczBlockStreamWriter] Block (%d) has Unknown type (%d) - Using Direct Writer", m_currentBlockIdx, m_header.type);
-                         m_currentBlockWriter = std::make_unique<DirectStreamWriter>(m_writeFn);
+                         m_currentBlockWriter->write(m_currentBlockPrefix.data(), m_currentBlockPrefix.size());
+                         m_currentBlockPrefix.clear();
+                    }
+
+                    if (m_currentBlockReadOffset >= m_currentBlockCompressedSize)
+                    {
+                         m_currentBlockWriter->close();
+                         m_currentBlockWriter = NULL;
+                         m_currentBlockIdx++;
+                         m_currentBlockCompressedSize = 0;
+                         continue;
                     }
                }
 
-               const u64 blockSize = m_blockSizes[m_currentBlockIdx];
+               const u64 blockSize = m_currentBlockCompressedSize;
                const u64 remaining = std::min(sz, blockSize - m_currentBlockReadOffset);
 
                m_currentBlockWriter->write(ptr, remaining);
@@ -573,11 +657,14 @@ public:
                     m_currentBlockWriter->close();
                     m_currentBlockWriter = NULL;
                     m_currentBlockIdx++;
+                    m_currentBlockCompressedSize = 0;
+                    m_currentBlockPrefix.clear();
                }
           }
      }
 
 private:
+     std::function<WriterFn> m_outputWriteFn;
      std::function<WriterFn> m_writeFn;
 
      NczBlockHeader m_header;
@@ -587,7 +674,10 @@ private:
 
      u64 m_currentBlockIdx;
      u64 m_currentBlockReadOffset;
+     u64 m_currentBlockCompressedSize = 0;
+     u64 m_totalDecompressedWritten = 0;
      std::unique_ptr<CloseableWriter> m_currentBlockWriter;
+     std::vector<u8> m_currentBlockPrefix;
 
      std::vector<u8> m_buffer; // For header + block-sizes parsing phases
 };

--- a/source/util/nczblock.cpp
+++ b/source/util/nczblock.cpp
@@ -1,0 +1,93 @@
+#include "util/nczblock.hpp"
+
+#include <cstring>
+
+namespace tin::nczblock
+{
+    bool HasZstdFrameMagic(const std::vector<std::uint8_t>& prefix)
+    {
+        if (prefix.size() < kZstdMagicSize)
+            return false;
+
+        std::uint32_t magic = 0;
+        std::memcpy(&magic, prefix.data(), sizeof(magic));
+        return magic == kZstdFrameMagic;
+    }
+
+    BlockDecodeMode DecideBlockDecodeMode(const std::uint8_t compressionType,
+                                          const std::uint64_t compressedSize,
+                                          const std::uint64_t expectedDecompressedSize,
+                                          const std::vector<std::uint8_t>& prefix,
+                                          const bool blockFinished)
+    {
+        if (compressionType != kTypeZstd)
+            return BlockDecodeMode::Direct;
+
+        if (HasZstdFrameMagic(prefix))
+            return BlockDecodeMode::Zstd;
+
+        if (!blockFinished && prefix.size() < kZstdMagicSize)
+            return BlockDecodeMode::NeedMoreData;
+
+        if (compressedSize == expectedDecompressedSize)
+            return BlockDecodeMode::Direct;
+
+        return BlockDecodeMode::Invalid;
+    }
+
+    const char* DescribeBlockDecodeMode(const BlockDecodeMode mode)
+    {
+        switch (mode)
+        {
+            case BlockDecodeMode::NeedMoreData:
+                return "need_more_data";
+            case BlockDecodeMode::Zstd:
+                return "zstd";
+            case BlockDecodeMode::Direct:
+                return "direct";
+            case BlockDecodeMode::Invalid:
+                return "invalid";
+        }
+
+        return "unknown";
+    }
+
+    bool ValidateStreamCompletion(const StreamValidationState& state, std::string& error)
+    {
+        if (!state.headerParsed)
+        {
+            error = "stream ended before NCZBLOCK header was fully read";
+            return false;
+        }
+
+        if (!state.blockSizesParsed)
+        {
+            error = "stream ended before NCZBLOCK block table was fully read";
+            return false;
+        }
+
+        if (state.currentBlockOpen)
+        {
+            if (state.currentBlockReadOffset != state.currentBlockCompressedSize)
+            {
+                error = "stream ended before current NCZBLOCK block was fully read";
+                return false;
+            }
+        }
+
+        if (state.currentBlockIndex != state.blockCount)
+        {
+            error = "stream ended before all NCZBLOCK blocks were consumed";
+            return false;
+        }
+
+        if (state.totalDecompressedWritten != state.expectedDecompressedSize)
+        {
+            error = "NCZBLOCK decompressed size mismatch";
+            return false;
+        }
+
+        error.clear();
+        return true;
+    }
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,19 +2,26 @@ CXX ?= c++
 CXXFLAGS ?= -std=c++20 -Wall -Wextra -O2
 
 ROOT := ..
-INCLUDES := -I$(ROOT)/include
-SOURCES := $(ROOT)/source/util/nczblock.cpp test_nczblock.cpp
-TARGET := test_nczblock
+DEVKITPRO ?= /opt/devkitpro
+INCLUDES := -I$(ROOT)/include -I$(DEVKITPRO)/libnx/include
+
+NCZBLOCK_SOURCES := $(ROOT)/source/util/nczblock.cpp test_nczblock.cpp
+CONTENT_META_SOURCES := $(ROOT)/source/data/byte_buffer.cpp $(ROOT)/source/nx/content_meta.cpp $(ROOT)/source/util/debug.c test_content_meta.cpp
+TARGETS := test_nczblock test_content_meta
 
 .PHONY: all run clean
 
-all: $(TARGET)
+all: $(TARGETS)
 
-$(TARGET): $(SOURCES)
-	$(CXX) $(CXXFLAGS) $(INCLUDES) $(SOURCES) -o $(TARGET)
+test_nczblock: $(NCZBLOCK_SOURCES)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $(NCZBLOCK_SOURCES) -o $@
 
-run: $(TARGET)
-	./$(TARGET)
+test_content_meta: $(CONTENT_META_SOURCES)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $(CONTENT_META_SOURCES) -o $@
+
+run: $(TARGETS)
+	./test_nczblock
+	./test_content_meta
 
 clean:
-	rm -f $(TARGET)
+	rm -f $(TARGETS)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,20 @@
+CXX ?= c++
+CXXFLAGS ?= -std=c++20 -Wall -Wextra -O2
+
+ROOT := ..
+INCLUDES := -I$(ROOT)/include
+SOURCES := $(ROOT)/source/util/nczblock.cpp test_nczblock.cpp
+TARGET := test_nczblock
+
+.PHONY: all run clean
+
+all: $(TARGET)
+
+$(TARGET): $(SOURCES)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $(SOURCES) -o $(TARGET)
+
+run: $(TARGET)
+	./$(TARGET)
+
+clean:
+	rm -f $(TARGET)

--- a/tests/test_content_meta.cpp
+++ b/tests/test_content_meta.cpp
@@ -1,0 +1,161 @@
+#include "nx/content_meta.hpp"
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+    [[noreturn]] void Fail(const std::string& message)
+    {
+        std::cerr << "FAIL: " << message << '\n';
+        std::exit(1);
+    }
+
+    void Expect(bool condition, const std::string& message)
+    {
+        if (!condition)
+            Fail(message);
+    }
+
+    void ExpectBytesEqual(const void* actual, const void* expected, std::size_t size, const std::string& message)
+    {
+        if (std::memcmp(actual, expected, size) != 0)
+            Fail(message);
+    }
+
+    NcmContentId MakeContentId(std::uint8_t seed)
+    {
+        NcmContentId id{};
+        for (std::size_t i = 0; i < sizeof(id.c); i++)
+            id.c[i] = static_cast<std::uint8_t>(seed + i);
+        return id;
+    }
+
+    NcmContentInfo MakeContentInfo(std::uint8_t seed, std::uint8_t type, std::uint64_t size)
+    {
+        NcmContentInfo info{};
+        info.content_id = MakeContentId(seed);
+        ncmU64ToContentInfoSize(size, &info);
+        info.content_type = type;
+        info.id_offset = static_cast<std::uint8_t>(seed ^ 0x5A);
+        return info;
+    }
+}
+
+int main()
+{
+    nx::ncm::PackagedContentMetaHeader packagedHeader{};
+    packagedHeader.title_id = 0x0100F43008C44000ULL;
+    packagedHeader.version = 0x1234;
+    packagedHeader.type = NcmContentMetaType_Patch;
+    packagedHeader.extended_header_size = sizeof(NcmPatchMetaExtendedHeader);
+    packagedHeader.content_count = 2;
+    packagedHeader.content_meta_count = 1;
+    packagedHeader.attributes = NcmContentMetaAttribute_Compacted;
+
+    NcmPatchMetaExtendedHeader patchHeader{};
+    patchHeader.application_id = 0x0100F43008C44800ULL;
+    patchHeader.required_system_version = 0x44556677;
+    patchHeader.extended_data_size = 4;
+
+    nx::ncm::PackagedContentInfo packagedInfos[2]{};
+    std::memset(packagedInfos[0].hash, 0x11, sizeof(packagedInfos[0].hash));
+    std::memset(packagedInfos[1].hash, 0x22, sizeof(packagedInfos[1].hash));
+    packagedInfos[0].content_info = MakeContentInfo(0x10, NcmContentType_Program, 0x123456);
+    packagedInfos[1].content_info = MakeContentInfo(0x20, NcmContentType_DeltaFragment, 0x654321);
+
+    NcmContentMetaInfo metaInfo{};
+    metaInfo.id = 0x0100F43008C44880ULL;
+    metaInfo.version = 0xCAFE;
+    metaInfo.type = NcmContentMetaType_Delta;
+    metaInfo.attr = 0x7F;
+
+    const std::array<std::uint8_t, 4> patchExtendedData{0xDE, 0xAD, 0xBE, 0xEF};
+
+    std::vector<std::uint8_t> packagedBytes(
+        sizeof(packagedHeader) +
+        sizeof(patchHeader) +
+        sizeof(packagedInfos) +
+        sizeof(metaInfo) +
+        patchExtendedData.size());
+
+    std::size_t offset = 0;
+    std::memcpy(packagedBytes.data() + offset, &packagedHeader, sizeof(packagedHeader));
+    offset += sizeof(packagedHeader);
+    std::memcpy(packagedBytes.data() + offset, &patchHeader, sizeof(patchHeader));
+    offset += sizeof(patchHeader);
+    std::memcpy(packagedBytes.data() + offset, &packagedInfos, sizeof(packagedInfos));
+    offset += sizeof(packagedInfos);
+    std::memcpy(packagedBytes.data() + offset, &metaInfo, sizeof(metaInfo));
+    offset += sizeof(metaInfo);
+    std::memcpy(packagedBytes.data() + offset, patchExtendedData.data(), patchExtendedData.size());
+
+    nx::ncm::ContentMeta meta(packagedBytes.data(), packagedBytes.size());
+
+    const auto installableInfos = meta.GetContentInfos();
+    Expect(installableInfos.size() == 1, "default content info view must still skip delta fragments");
+    Expect(installableInfos[0].content_type == NcmContentType_Program,
+           "installable content records must keep the non-delta entry");
+
+    const auto allInfos = meta.GetContentInfos(true);
+    Expect(allInfos.size() == 2, "metadata view must keep delta fragment records");
+    Expect(allInfos[1].content_type == NcmContentType_DeltaFragment,
+           "delta fragment record must remain present for patch metadata");
+
+    NcmContentInfo cnmtContentInfo = MakeContentInfo(0x30, NcmContentType_Meta, 0x1111);
+    tin::data::ByteBuffer installContentMeta;
+    meta.GetInstallContentMeta(installContentMeta, cnmtContentInfo, false);
+
+    Expect(installContentMeta.GetSize() ==
+               sizeof(NcmContentMetaHeader) +
+               sizeof(NcmPatchMetaExtendedHeader) +
+               sizeof(NcmContentInfo) * 3 +
+               sizeof(metaInfo) +
+               patchExtendedData.size(),
+           "install content meta size must preserve the packaged tail");
+
+    const auto* installHeader = reinterpret_cast<const NcmContentMetaHeader*>(installContentMeta.GetData());
+    Expect(installHeader->extended_header_size == sizeof(NcmPatchMetaExtendedHeader),
+           "install header must keep patch extended header size");
+    Expect(installHeader->content_count == 3,
+           "install header must include cnmt plus all packaged content records");
+    Expect(installHeader->content_meta_count == 1,
+           "install header must keep content meta count");
+    Expect(installHeader->attributes == NcmContentMetaAttribute_Compacted,
+           "install header must keep metadata attributes");
+
+    const auto* installPatchHeader = reinterpret_cast<const NcmPatchMetaExtendedHeader*>(
+        installContentMeta.GetData() + sizeof(NcmContentMetaHeader));
+    ExpectBytesEqual(installPatchHeader, &patchHeader, sizeof(patchHeader),
+                     "patch extended header must be copied verbatim");
+
+    const auto* installInfos = reinterpret_cast<const NcmContentInfo*>(
+        installContentMeta.GetData() +
+        sizeof(NcmContentMetaHeader) +
+        sizeof(NcmPatchMetaExtendedHeader));
+    ExpectBytesEqual(&installInfos[0], &cnmtContentInfo, sizeof(NcmContentInfo),
+                     "cnmt content record must be inserted first");
+    ExpectBytesEqual(&installInfos[1], &packagedInfos[0].content_info, sizeof(NcmContentInfo),
+                     "program content record must be preserved");
+    ExpectBytesEqual(&installInfos[2], &packagedInfos[1].content_info, sizeof(NcmContentInfo),
+                     "delta fragment record must remain in patch metadata");
+
+    const std::size_t installTailOffset =
+        sizeof(NcmContentMetaHeader) +
+        sizeof(NcmPatchMetaExtendedHeader) +
+        sizeof(NcmContentInfo) * 3;
+    ExpectBytesEqual(installContentMeta.GetData() + installTailOffset, &metaInfo, sizeof(metaInfo),
+                     "metadata tail must preserve content meta info bytes");
+    ExpectBytesEqual(installContentMeta.GetData() + installTailOffset + sizeof(metaInfo),
+                     patchExtendedData.data(),
+                     patchExtendedData.size(),
+                     "metadata tail must preserve patch extended data bytes");
+
+    std::cout << "All content meta tests passed\n";
+    return 0;
+}

--- a/tests/test_nczblock.cpp
+++ b/tests/test_nczblock.cpp
@@ -1,0 +1,147 @@
+#include "util/nczblock.hpp"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+    [[noreturn]] void Fail(const std::string& message)
+    {
+        std::cerr << "FAIL: " << message << '\n';
+        std::exit(1);
+    }
+
+    void Expect(bool condition, const std::string& message)
+    {
+        if (!condition)
+            Fail(message);
+    }
+
+    std::vector<std::uint8_t> ZstdMagicPrefix()
+    {
+        const std::uint32_t magic = tin::nczblock::kZstdFrameMagic;
+        return {
+            static_cast<std::uint8_t>(magic & 0xFF),
+            static_cast<std::uint8_t>((magic >> 8) & 0xFF),
+            static_cast<std::uint8_t>((magic >> 16) & 0xFF),
+            static_cast<std::uint8_t>((magic >> 24) & 0xFF),
+        };
+    }
+}
+
+int main()
+{
+    using tin::nczblock::BlockDecodeMode;
+    using tin::nczblock::StreamValidationState;
+
+    {
+        const auto mode = tin::nczblock::DecideBlockDecodeMode(
+            tin::nczblock::kTypeZstd,
+            0x4000,
+            0x4000,
+            ZstdMagicPrefix(),
+            false);
+        Expect(mode == BlockDecodeMode::Zstd,
+               "equal-size zstd block with zstd magic must decode as zstd");
+    }
+
+    {
+        const auto mode = tin::nczblock::DecideBlockDecodeMode(
+            tin::nczblock::kTypeZstd,
+            0x4000,
+            0x4000,
+            {0x11, 0x22, 0x33, 0x44},
+            true);
+        Expect(mode == BlockDecodeMode::Direct,
+               "equal-size block without zstd magic may fall back to direct");
+    }
+
+    {
+        const auto mode = tin::nczblock::DecideBlockDecodeMode(
+            tin::nczblock::kTypeZstd,
+            0x3000,
+            0x4000,
+            {0x11, 0x22, 0x33, 0x44},
+            true);
+        Expect(mode == BlockDecodeMode::Invalid,
+               "compressed block without zstd magic must be rejected");
+    }
+
+    {
+        const auto mode = tin::nczblock::DecideBlockDecodeMode(
+            tin::nczblock::kTypeZstd,
+            0x3000,
+            0x4000,
+            {0x28, 0xB5},
+            false);
+        Expect(mode == BlockDecodeMode::NeedMoreData,
+               "short prefix must request more data before decode decision");
+    }
+
+    {
+        StreamValidationState state;
+        state.headerParsed = true;
+        state.blockSizesParsed = true;
+        state.blockCount = 3;
+        state.currentBlockIndex = 3;
+        state.totalDecompressedWritten = 0x9000;
+        state.expectedDecompressedSize = 0x9000;
+
+        std::string error;
+        Expect(tin::nczblock::ValidateStreamCompletion(state, error),
+               "complete stream state should validate");
+        Expect(error.empty(), "successful validation should clear error");
+    }
+
+    {
+        StreamValidationState state;
+        state.headerParsed = true;
+        state.blockSizesParsed = true;
+        state.blockCount = 3;
+        state.currentBlockIndex = 2;
+        state.totalDecompressedWritten = 0x9000;
+        state.expectedDecompressedSize = 0x9000;
+
+        std::string error;
+        Expect(!tin::nczblock::ValidateStreamCompletion(state, error),
+               "missing block consumption must fail validation");
+        Expect(!error.empty(), "failed validation must set error");
+    }
+
+    {
+        StreamValidationState state;
+        state.headerParsed = true;
+        state.blockSizesParsed = true;
+        state.blockCount = 1;
+        state.currentBlockIndex = 1;
+        state.currentBlockOpen = true;
+        state.currentBlockReadOffset = 0x1000;
+        state.currentBlockCompressedSize = 0x2000;
+        state.totalDecompressedWritten = 0x2000;
+        state.expectedDecompressedSize = 0x2000;
+
+        std::string error;
+        Expect(!tin::nczblock::ValidateStreamCompletion(state, error),
+               "partial current block must fail validation");
+    }
+
+    {
+        StreamValidationState state;
+        state.headerParsed = true;
+        state.blockSizesParsed = true;
+        state.blockCount = 1;
+        state.currentBlockIndex = 1;
+        state.totalDecompressedWritten = 0x1FFF;
+        state.expectedDecompressedSize = 0x2000;
+
+        std::string error;
+        Expect(!tin::nczblock::ValidateStreamCompletion(state, error),
+               "decompressed size mismatch must fail validation");
+    }
+
+    std::cout << "All NCZBLOCK tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
This PR fixes the install hang where CyberFoil becomes unresponsive after successfully installing DLC/update files.

## Changes

- Finalize buffered placeholder writers explicitly after HTTP/USB installs so NCZ/NCZBLOCK streams are fully closed and validated.
- Improve NCZBLOCK block detection by checking Zstd frame magic instead of relying only on compressed size.
- Reject incomplete/trailing NCZBLOCK streams instead of silently accepting bad state.
- Release shop install NCA writer/storage handles after each completed entry to avoid handle buildup.
- Preserve patch metadata content records and packaged tail data, including delta fragment records needed for valid patch metadata.
- Add local tests for NCZBLOCK decode decisions, stream completion validation, and content metadata preservation.