### PR TITLE
input: allow all controllers slots - fix hdmi dock usage

### DIFF
--- a/source/ui/MainApplication.cpp
+++ b/source/ui/MainApplication.cpp
@@ -92,13 +92,14 @@ namespace inst::ui {
             return;
 
         if (force || regainedFocus || !padIsConnected(&this->input_pad)) {
-            padConfigureInput(1, HidNpadStyleSet_NpadStandard);
-            padInitializeDefault(&this->input_pad);
+            padConfigureInput(8, HidNpadStyleSet_NpadStandard);
+            padInitializeAny(&this->input_pad);
         }
     }
 
     void MainApplication::OnLoad() {
         mainApp = this;
+        this->RefreshInputDevice(true);
 
         Language::Load();
 


### PR DESCRIPTION
When multiple controllers are connected, launching Cyberfoil with the wrong controller can leave the user unable to interact with the app at all - including exiting since the app previously only read input from HidNpadIdType_No1 and HidNpadIdType_Handheld.