### PR TITLE
feat: install queue and download speed optimizations

### DIFF
--- a/include/ui/shopInstPage.hpp
+++ b/include/ui/shopInstPage.hpp
@@ -46,6 +46,7 @@ namespace inst::ui {
             Rectangle::Ref batteryOutline;
             Rectangle::Ref batteryFill;
             Rectangle::Ref batteryCap;
+            TextBlock::Ref queueStatusText;
         private:
             enum class BrowseSortMode {
                 Default,

--- a/include/util/install_queue.hpp
+++ b/include/util/install_queue.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+#include "shopInstall.hpp"
+
+namespace inst::queue {
+
+    enum class QueueItemState {
+        Pending,
+        Installing,
+        Success,
+        Failed,
+        Canceled
+    };
+
+    struct QueueItem {
+        shopInstStuff::ShopItem shopItem;
+        int storageId = 0;              // 0 = SD, 1 = NAND
+        std::string sourceLabel;
+        QueueItemState state = QueueItemState::Pending;
+        double progress = 0.0;          // 0.0 - 100.0
+        std::string statusText;
+        std::string errorText;
+    };
+
+    // Snapshot of the queue state for UI consumption (thread-safe copy)
+    struct QueueSnapshot {
+        std::vector<QueueItem> items;
+        std::size_t currentIndex = 0;
+        bool workerRunning = false;
+        std::size_t completedCount = 0;
+        std::size_t failedCount = 0;
+        std::size_t totalCount = 0;
+    };
+
+    class InstallQueue {
+    public:
+        static InstallQueue& Instance();
+
+        // Add items to the queue. Starts the worker if not already running.
+        void Enqueue(const std::vector<shopInstStuff::ShopItem>& items, int storageId, const std::string& sourceLabel);
+
+        // Get a thread-safe snapshot of the current queue state for UI rendering.
+        QueueSnapshot GetSnapshot() const;
+
+        // Check if the worker is currently processing.
+        bool IsRunning() const;
+
+        // Check if there are pending or in-progress items.
+        bool HasPending() const;
+
+        // Get a short status string for overlay display (e.g. "Installing 2/5: Game Name")
+        std::string GetStatusText() const;
+
+        // Get progress of the current item (0.0 - 100.0), or -1 if idle.
+        double GetCurrentProgress() const;
+
+        // Cancel all pending items (current install finishes, rest are dropped).
+        void CancelPending();
+
+        // Clear completed/failed items from the queue.
+        void ClearFinished();
+
+        // Called by the install worker to update progress of the current item.
+        // This is meant to be called from the worker thread.
+        void ReportProgress(double percent, const std::string& statusText);
+
+        // Flag that signals the UI has new data to display (polled by UI thread).
+        bool ConsumeUiDirtyFlag();
+
+        // Pop the next batch of pending items for installation (main-thread driven).
+        // Returns true if a batch was found. Marks those items as Installing.
+        bool PopNextBatch(std::vector<shopInstStuff::ShopItem>& outItems, int& outStorageId, std::string& outSourceLabel);
+
+        // Mark the current installing batch as complete (success or failure).
+        void MarkBatchComplete(bool success);
+
+    private:
+        InstallQueue() = default;
+        ~InstallQueue();
+        InstallQueue(const InstallQueue&) = delete;
+        InstallQueue& operator=(const InstallQueue&) = delete;
+
+        void EnsureWorkerRunning();
+        void WorkerMain();
+        void InstallSingleItem(QueueItem& item);
+
+        mutable std::mutex m_mutex;
+        std::deque<QueueItem> m_queue;
+        std::size_t m_currentIndex = 0;
+        std::size_t m_completedCount = 0;
+        std::size_t m_failedCount = 0;
+        std::thread m_workerThread;
+        std::atomic<bool> m_workerRunning{false};
+        std::atomic<bool> m_stopRequested{false};
+        std::atomic<bool> m_uiDirty{false};
+    };
+
+} // namespace inst::queue

--- a/source/install/http_nsp.cpp
+++ b/source/install/http_nsp.cpp
@@ -120,6 +120,7 @@ namespace tin::install::nsp
                         return 0;
                     if (args->bufferedPlaceholderWriter->CanAppendData(streamBufSize))
                         break;
+                    svcSleepThread(100000ULL); // 0.1ms yield to avoid busy-spin
                 }
 
                 args->bufferedPlaceholderWriter->AppendData(streamBuf, streamBufSize);
@@ -154,6 +155,8 @@ namespace tin::install::nsp
                 }
                 if (args->bufferedPlaceholderWriter->CanWriteSegmentToPlaceholder())
                     args->bufferedPlaceholderWriter->WriteSegmentToPlaceholder();
+                else
+                    svcSleepThread(100000ULL); // 0.1ms yield to avoid busy-spin
             }
         }
         catch (...) {

--- a/source/shopInstall.cpp
+++ b/source/shopInstall.cpp
@@ -30,6 +30,7 @@
 #include "util/error.hpp"
 #include "util/hauth.hpp"
 #include "util/install_diagnostics.hpp"
+#include "util/install_queue.hpp"
 #include "util/json.hpp"
 #include "util/lang.hpp"
 #include "util/network_util.hpp"
@@ -2365,8 +2366,21 @@ namespace shopInstStuff {
         }
 
         LOG_DEBUG("Done");
+        inst::queue::InstallQueue::Instance().MarkBatchComplete(nspInstalled);
+
+        // Check if there are more items in the queue
+        std::vector<ShopItem> nextBatch;
+        int nextStorageId = 0;
+        std::string nextSourceLabel;
+        if (inst::queue::InstallQueue::Instance().PopNextBatch(nextBatch, nextStorageId, nextSourceLabel)) {
+            // Continue with next batch without returning to shop
+            inst::ui::instPage::loadMainMenu();
+            inst::util::deinitInstallServices();
+            installTitleShop(nextBatch, nextStorageId, nextSourceLabel);
+            return;
+        }
+
         inst::ui::instPage::loadMainMenu();
         inst::util::deinitInstallServices();
     }
 }
-

--- a/source/ui/shopInstPage.cpp
+++ b/source/ui/shopInstPage.cpp
@@ -15,6 +15,7 @@
 #include "ui/overflowText.hpp"
 #include "util/config.hpp"
 #include "util/curl.hpp"
+#include "util/install_queue.hpp"
 #include "util/lang.hpp"
 #include "util/offline_title_db.hpp"
 #include "util/save_sync.hpp"
@@ -942,6 +943,9 @@ namespace inst::ui {
         this->searchInfoText->SetVisible(false);
         this->butText = TextBlock::New(10, 678, "", 20);
         this->butText->SetColor(COLOR("#FFFFFFFF"));
+        this->queueStatusText = TextBlock::New(0, 678, "", 18);
+        this->queueStatusText->SetColor(COLOR("#4CD964FF"));
+        this->queueStatusText->SetVisible(false);
         this->setButtonsText("inst.shop.buttons_loading"_lang);
         this->menu = pu::ui::elm::Menu::New(0, 136, 1280, COLOR("#FFFFFF00"), 36, 14, 22);
         if (inst::config::oledMode) {
@@ -1063,6 +1067,7 @@ namespace inst::ui {
         this->Add(this->timeText);
         this->Add(this->ipText);
         this->Add(this->butText);
+        this->Add(this->queueStatusText);
         this->Add(this->pageInfoText);
         this->Add(this->loadingProgressText);
         this->Add(this->loadingBarBack);
@@ -3990,6 +3995,9 @@ namespace inst::ui {
     }
 
     void shopInstPage::refreshAfterInstall() {
+        // Clear finished queue items
+        inst::queue::InstallQueue::Instance().ClearFinished();
+
         if (this->shopSections.empty() || this->activeShopUrl.empty()) {
             this->startShop(true);
             return;
@@ -4171,9 +4179,9 @@ namespace inst::ui {
         int dialogResult = -1;
         if (this->selectedItems.size() == 1) {
             std::string name = inst::util::shortenString(this->selectedItems[0].name, 32, true);
-            dialogResult = mainApp->CreateShowDialog("inst.target.desc0"_lang + name + "inst.target.desc1"_lang, "common.cancel_desc"_lang, {"inst.target.opt0"_lang, "inst.target.opt1"_lang}, false);
+            dialogResult = mainApp->CreateShowDialog("inst.target.desc0"_lang + name + "inst.target.desc1"_lang, "common.cancel_desc"_lang, {"inst.target.opt0"_lang, "inst.target.opt1"_lang, "Queue (SD)", "Queue (NAND)"}, false);
         } else {
-            dialogResult = mainApp->CreateShowDialog("inst.target.desc00"_lang + std::to_string(this->selectedItems.size()) + "inst.target.desc01"_lang, "common.cancel_desc"_lang, {"inst.target.opt0"_lang, "inst.target.opt1"_lang}, false);
+            dialogResult = mainApp->CreateShowDialog("inst.target.desc00"_lang + std::to_string(this->selectedItems.size()) + "inst.target.desc01"_lang, "common.cancel_desc"_lang, {"inst.target.opt0"_lang, "inst.target.opt1"_lang, "Queue (SD)", "Queue (NAND)"}, false);
         }
         if (dialogResult == -1) {
             if (!autoAddedItems.empty()) {
@@ -4204,11 +4212,59 @@ namespace inst::ui {
         }
 
         this->updateRememberedSelection();
-        shopInstStuff::installTitleShop(this->selectedItems, dialogResult, "inst.shop.source_string"_lang);
-        this->refreshAfterInstall();
+        auto& queue = inst::queue::InstallQueue::Instance();
+
+        if (dialogResult == 2 || dialogResult == 3) {
+            // "Queue (SD)" = 2, "Queue (NAND)" = 3 - add to queue, stay in shop
+            int queueStorage = (dialogResult == 3) ? 1 : 0;
+            queue.Enqueue(this->selectedItems, queueStorage, "inst.shop.source_string"_lang);
+            this->selectedItems.clear();
+            if (this->shopGridMode)
+                this->updateShopGrid();
+            else
+                this->drawMenuItems(false);
+            return;
+        }
+
+        // dialogResult 0 = SD, 1 = NAND - start install immediately
+        queue.Enqueue(this->selectedItems, dialogResult, "inst.shop.source_string"_lang);
+        this->selectedItems.clear();
+
+        // Pop and start the batch
+        std::vector<shopInstStuff::ShopItem> batch;
+        int batchStorage = 0;
+        std::string batchSource;
+        if (queue.PopNextBatch(batch, batchStorage, batchSource)) {
+            shopInstStuff::installTitleShop(batch, batchStorage, batchSource);
+            this->refreshAfterInstall();
+            return;
+        }
+
+        // Fallback: refresh shop view
+        if (this->shopGridMode)
+            this->updateShopGrid();
+        else
+            this->drawMenuItems(false);
     }
 
     void shopInstPage::onInput(u64 Down, u64 Up, u64 Held, pu::ui::Touch Pos) {
+        // Update queue status indicator
+        {
+            auto& queue = inst::queue::InstallQueue::Instance();
+            if (queue.ConsumeUiDirtyFlag() || queue.HasPending()) {
+                std::string status = queue.GetStatusText();
+                if (!status.empty()) {
+                    if (queue.HasPending() && !queue.IsRunning())
+                        status += "  [+] Start";
+                    this->queueStatusText->SetText(status);
+                    this->queueStatusText->SetX(1280 - 10 - this->queueStatusText->GetTextWidth());
+                    this->queueStatusText->SetVisible(true);
+                } else {
+                    this->queueStatusText->SetVisible(false);
+                }
+            }
+        }
+
         int bottomTapX = 0;
         if (DetectBottomHintTap(Pos, this->bottomHintTouch, 668, 52, bottomTapX)) {
             Down |= FindBottomHintButton(this->bottomHintSegments, bottomTapX);
@@ -4312,7 +4368,20 @@ namespace inst::ui {
         if (this->shopGridMode) {
             if (Down & HidNpadButton_Plus) {
                 if (!this->isInstalledSection() && !this->isSaveSyncSection() && !this->visibleItems.empty() && this->selectedItems.empty()) {
-                    this->selectTitle(this->shopGridIndex);
+                    // If no items selected but queue has pending items, start the queue
+                    auto& queue = inst::queue::InstallQueue::Instance();
+                    if (queue.HasPending()) {
+                        std::vector<shopInstStuff::ShopItem> batch;
+                        int batchStorage = 0;
+                        std::string batchSource;
+                        if (queue.PopNextBatch(batch, batchStorage, batchSource)) {
+                            shopInstStuff::installTitleShop(batch, batchStorage, batchSource);
+                            this->refreshAfterInstall();
+                            return;
+                        }
+                    } else {
+                        this->selectTitle(this->shopGridIndex);
+                    }
                 }
                 if (!this->isInstalledSection() && !this->isSaveSyncSection() && !this->selectedItems.empty())
                     this->startInstall();
@@ -4605,7 +4674,20 @@ namespace inst::ui {
         if (Down & HidNpadButton_Plus) {
             if (!this->isInstalledSection() && !this->isSaveSyncSection()) {
                 if (this->selectedItems.empty()) {
-                    this->selectTitle(this->menu->GetSelectedIndex());
+                    // If no items selected but queue has pending items, start the queue
+                    auto& queue = inst::queue::InstallQueue::Instance();
+                    if (queue.HasPending()) {
+                        std::vector<shopInstStuff::ShopItem> batch;
+                        int batchStorage = 0;
+                        std::string batchSource;
+                        if (queue.PopNextBatch(batch, batchStorage, batchSource)) {
+                            shopInstStuff::installTitleShop(batch, batchStorage, batchSource);
+                            this->refreshAfterInstall();
+                            return;
+                        }
+                    } else {
+                        this->selectTitle(this->menu->GetSelectedIndex());
+                    }
                 }
                 if (!this->selectedItems.empty()) this->startInstall();
             }

--- a/source/util/install_queue.cpp
+++ b/source/util/install_queue.cpp
@@ -1,0 +1,209 @@
+#include "util/install_queue.hpp"
+#include "util/util.hpp"
+#include "util/config.hpp"
+#include "shopInstall.hpp"
+#include <algorithm>
+#include <cstdio>
+
+namespace inst::queue {
+
+    InstallQueue& InstallQueue::Instance() {
+        static InstallQueue instance;
+        return instance;
+    }
+
+    InstallQueue::~InstallQueue() {
+        m_stopRequested.store(true);
+        if (m_workerThread.joinable())
+            m_workerThread.join();
+    }
+
+    void InstallQueue::Enqueue(const std::vector<shopInstStuff::ShopItem>& items, int storageId, const std::string& sourceLabel) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        for (const auto& item : items) {
+            QueueItem qi;
+            qi.shopItem = item;
+            qi.storageId = storageId;
+            qi.sourceLabel = sourceLabel;
+            qi.state = QueueItemState::Pending;
+            qi.statusText = "Queued";
+            m_queue.push_back(std::move(qi));
+        }
+        m_uiDirty.store(true);
+    }
+
+    QueueSnapshot InstallQueue::GetSnapshot() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        QueueSnapshot snap;
+        snap.items.assign(m_queue.begin(), m_queue.end());
+        snap.currentIndex = m_currentIndex;
+        snap.workerRunning = m_workerRunning.load();
+        snap.completedCount = m_completedCount;
+        snap.failedCount = m_failedCount;
+        snap.totalCount = m_queue.size();
+        return snap;
+    }
+
+    bool InstallQueue::IsRunning() const {
+        return m_workerRunning.load();
+    }
+
+    bool InstallQueue::HasPending() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        for (const auto& item : m_queue) {
+            if (item.state == QueueItemState::Pending || item.state == QueueItemState::Installing)
+                return true;
+        }
+        return false;
+    }
+
+    std::string InstallQueue::GetStatusText() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_queue.empty())
+            return "";
+
+        std::size_t pendingAndInstalling = 0;
+        std::string currentName;
+        for (const auto& q : m_queue) {
+            if (q.state == QueueItemState::Installing) {
+                currentName = q.shopItem.name;
+                pendingAndInstalling++;
+            } else if (q.state == QueueItemState::Pending) {
+                pendingAndInstalling++;
+            }
+        }
+
+        if (!currentName.empty()) {
+            if (currentName.size() > 28)
+                currentName = currentName.substr(0, 25) + "...";
+            return "Installing " + std::to_string(m_completedCount + 1) + "/" +
+                   std::to_string(m_completedCount + pendingAndInstalling) + ": " + currentName;
+        }
+
+        if (pendingAndInstalling > 0)
+            return "Queue: " + std::to_string(pendingAndInstalling) + " pending";
+
+        if (m_completedCount > 0 && m_failedCount == 0)
+            return "Done (" + std::to_string(m_completedCount) + " installed)";
+
+        if (m_failedCount > 0)
+            return "Done (" + std::to_string(m_completedCount) + " ok, " + std::to_string(m_failedCount) + " failed)";
+
+        return "";
+    }
+
+    double InstallQueue::GetCurrentProgress() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        for (const auto& item : m_queue) {
+            if (item.state == QueueItemState::Installing)
+                return item.progress;
+        }
+        return -1.0;
+    }
+
+    void InstallQueue::CancelPending() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        for (auto& item : m_queue) {
+            if (item.state == QueueItemState::Pending) {
+                item.state = QueueItemState::Canceled;
+                item.statusText = "Canceled";
+            }
+        }
+        m_uiDirty.store(true);
+    }
+
+    void InstallQueue::ClearFinished() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_queue.erase(
+            std::remove_if(m_queue.begin(), m_queue.end(), [](const QueueItem& item) {
+                return item.state == QueueItemState::Success ||
+                       item.state == QueueItemState::Failed ||
+                       item.state == QueueItemState::Canceled;
+            }),
+            m_queue.end()
+        );
+        m_completedCount = 0;
+        m_failedCount = 0;
+        m_currentIndex = 0;
+        m_uiDirty.store(true);
+    }
+
+    void InstallQueue::ReportProgress(double percent, const std::string& statusText) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        for (auto& item : m_queue) {
+            if (item.state == QueueItemState::Installing) {
+                item.progress = percent;
+                if (!statusText.empty())
+                    item.statusText = statusText;
+                break;
+            }
+        }
+        m_uiDirty.store(true);
+    }
+
+    bool InstallQueue::ConsumeUiDirtyFlag() {
+        return m_uiDirty.exchange(false);
+    }
+
+    bool InstallQueue::PopNextBatch(std::vector<shopInstStuff::ShopItem>& outItems, int& outStorageId, std::string& outSourceLabel) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        outItems.clear();
+        bool foundFirst = false;
+
+        for (auto& item : m_queue) {
+            if (item.state != QueueItemState::Pending)
+                continue;
+            if (!foundFirst) {
+                outStorageId = item.storageId;
+                outSourceLabel = item.sourceLabel;
+                foundFirst = true;
+            }
+            if (item.storageId == outStorageId && item.sourceLabel == outSourceLabel) {
+                item.state = QueueItemState::Installing;
+                item.statusText = "Installing...";
+                outItems.push_back(item.shopItem);
+            } else {
+                break;
+            }
+        }
+
+        if (!outItems.empty()) {
+            m_workerRunning.store(true);
+            m_uiDirty.store(true);
+        }
+        return !outItems.empty();
+    }
+
+    void InstallQueue::MarkBatchComplete(bool success) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        for (auto& item : m_queue) {
+            if (item.state == QueueItemState::Installing) {
+                if (success) {
+                    item.state = QueueItemState::Success;
+                    item.statusText = "Installed";
+                    item.progress = 100.0;
+                    m_completedCount++;
+                } else {
+                    item.state = QueueItemState::Failed;
+                    item.statusText = "Failed";
+                    m_failedCount++;
+                }
+            }
+        }
+        m_workerRunning.store(false);
+        m_uiDirty.store(true);
+    }
+
+    void InstallQueue::EnsureWorkerRunning() {
+        // Not used in main-thread-driven approach
+    }
+
+    void InstallQueue::WorkerMain() {
+        // Not used in main-thread-driven approach
+    }
+
+    void InstallQueue::InstallSingleItem(QueueItem& item) {
+        (void)item;
+    }
+
+} // namespace inst::queue

--- a/source/util/network_util.cpp
+++ b/source/util/network_util.cpp
@@ -223,6 +223,12 @@ namespace tin::network
         curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 8L);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &callbackCtx);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &ParseHTMLDataCallback);
+        curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, 512L * 1024L);
+        curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 1L);
+        curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
+        curl_easy_setopt(curl, CURLOPT_TCP_KEEPIDLE, 30L);
+        curl_easy_setopt(curl, CURLOPT_TCP_KEEPINTVL, 15L);
+        curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
         std::string authValue;
         ApplyBasicAuth(curl, authValue);
 
@@ -322,6 +328,8 @@ namespace tin::network
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, false);
         const std::string& userAgent = inst::curl::getUserAgent();
         curl_easy_setopt(curl, CURLOPT_USERAGENT, userAgent.c_str());
+        curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 1L);
+        curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
         curl_easy_setopt(curl, CURLOPT_HEADERDATA, this);
         curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, &tin::network::HTTPHeader::ParseHTMLHeader);
         std::string authValue;


### PR DESCRIPTION
- Add install queue system for shop installations
  - New 'Queue (SD)' and 'Queue (NAND)' options in install dialog
  - Queue status indicator on shop page (green text, bottom right)
  - Press + with no selection to start queued installations
  - Automatic continuation: queued batches install sequentially
  - After all installs complete, returns to shop page

- Improve HTTP download performance
  - Set CURLOPT_BUFFERSIZE to 512KB (was default 16KB)
  - Enable TCP_NODELAY to disable Nagle's algorithm
  - Enable TCP_KEEPALIVE with 30s idle / 15s interval
  - Add CURLOPT_NOSIGNAL for thread safety
  - Replace busy-wait loops with 0.1ms yields in download/write threads