### PR TITLE
Improve remote download stability on large titles

### DIFF
--- a/source/install/http_nsp.cpp
+++ b/source/install/http_nsp.cpp
@@ -40,6 +40,10 @@ namespace inst::ui { extern MainApplication *mainApp; }
 namespace tin::install::nsp
 {
     namespace {
+        // How many full StreamDataRange cycles to auto-approve before showing UI.
+        // Raise for more "sleep/wake"-style recovery without user input.
+        constexpr int kAutoRetryCycles = 5;
+
         std::string DeriveDisplayNameFromUrl(const std::string& url)
         {
             const std::size_t fragmentPos = url.find('#');
@@ -104,6 +108,7 @@ namespace tin::install::nsp
         u64 pfs0Offset;
         u64 ncaSize;
         RetryConfirmState retryConfirm;
+        std::atomic<int> autoRetryCyclesLeft{kAutoRetryCycles};
     };
 
     int CurlStreamFunc(void* in)
@@ -126,10 +131,29 @@ namespace tin::install::nsp
                 return streamBufSize;
             };
 
+            // Auto-approve several full retry cycles (Range resume) without UI.
+            // After those are used, fall back to the existing Yes/No dialog once.
             auto retryConfirmFunc = [&]() -> bool {
+                if (stopThreadsHttpNsp || inst::ui::instPage::isInstallCancelRequested())
+                    return false;
+
+                int left = args->autoRetryCyclesLeft.load();
+                while (left > 0) {
+                    if (args->autoRetryCyclesLeft.compare_exchange_weak(left, left - 1)) {
+                        LOG_DEBUG("HTTPNSP: auto-approve retry cycle, remaining=%d\n", left - 1);
+                        svcSleepThread(1000000000ULL); // 1s pause before next cycle
+                        return !stopThreadsHttpNsp &&
+                               !inst::ui::instPage::isInstallCancelRequested();
+                    }
+                    left = args->autoRetryCyclesLeft.load();
+                }
+
+                // Silent cycles exhausted — ask the user
+                args->retryConfirm.approved.store(false);
                 args->retryConfirm.pending.store(true);
                 while (args->retryConfirm.pending.load() && !stopThreadsHttpNsp)
                     svcSleepThread(50 * 1000 * 1000ULL);
+
                 return !stopThreadsHttpNsp && args->retryConfirm.approved.load();
             };
 
@@ -178,6 +202,7 @@ namespace tin::install::nsp
         args.bufferedPlaceholderWriter = &bufferedPlaceholderWriter;
         args.pfs0Offset = this->GetDataOffset() + fileEntry->dataOffset;
         args.ncaSize = ncaSize;
+        args.autoRetryCyclesLeft.store(kAutoRetryCycles);
         thrd_t curlThread;
         thrd_t writeThread;
 

--- a/source/util/curl.cpp
+++ b/source/util/curl.cpp
@@ -188,9 +188,9 @@ static size_t writeDataFileAtOffset(void *ptr, size_t size, size_t nmemb, void *
     return fwrite(ptr, size, nmemb, ctx->file);
 }
 
-static constexpr long kDefaultConnectTimeoutMs = 15000;
+static constexpr long kDefaultConnectTimeoutMs = 30000;
 static constexpr long kLowSpeedLimitBytesPerSec = 1;
-static constexpr long kLowSpeedTimeSeconds = 45;
+static constexpr long kLowSpeedTimeSeconds = 15;
 static constexpr long kFileDownloadCurlBufferSize = 512L * 1024L;
 static constexpr std::size_t kFileDownloadIoBufferSize = 1024U * 1024U;
 
@@ -211,7 +211,7 @@ static void removeFileIfExistsNoThrow(const char* path) {
     std::filesystem::remove(path, ec);
 }
 
-static void applyCommonCurlOptions(CURL *curl_handle, const std::string& url, long timeout, bool writeProgress) {
+static void applyCommonCurlOptions(CURL *curl_handle, const std::string& url, long timeout, bool writeProgress, bool forceNewConnection = false) {
     curl_easy_setopt(curl_handle, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl_handle, CURLOPT_SSL_VERIFYPEER, 0L);
@@ -221,6 +221,12 @@ static void applyCommonCurlOptions(CURL *curl_handle, const std::string& url, lo
     curl_easy_setopt(curl_handle, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(curl_handle, CURLOPT_BUFFERSIZE, kFileDownloadCurlBufferSize);
     curl_easy_setopt(curl_handle, CURLOPT_TCP_KEEPALIVE, 1L);
+    // Do NOT set TCP_KEEPIDLE / TCP_KEEPINTVL (speed regression)
+
+    if (forceNewConnection) {
+        curl_easy_setopt(curl_handle, CURLOPT_FRESH_CONNECT, 1L);
+        curl_easy_setopt(curl_handle, CURLOPT_FORBID_REUSE, 1L);
+    }
 
     if (writeProgress) {
         curl_easy_setopt(curl_handle, CURLOPT_NOPROGRESS, 0L);

--- a/source/util/network_util.cpp
+++ b/source/util/network_util.cpp
@@ -215,6 +215,8 @@ namespace tin::network
 
         curl_easy_setopt(curl, CURLOPT_URL, requestUrl.c_str());
         curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, false);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+        curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
         const std::string& userAgent = inst::curl::getUserAgent();
         curl_easy_setopt(curl, CURLOPT_USERAGENT, userAgent.c_str());
         curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "identity");
@@ -223,6 +225,21 @@ namespace tin::network
         curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 8L);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &callbackCtx);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &ParseHTMLDataCallback);
+
+        // Larger receive buffer (throughput)
+        curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, 512L * 1024L);
+
+        // Stall at ~0 B/s → abort this attempt (~15s), then StreamDataRange retries
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 15L);
+        curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 30000L);
+
+        // New TCP each range attempt (don't reuse a half-dead connection)
+        curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1L);
+        curl_easy_setopt(curl, CURLOPT_FORBID_REUSE, 1L);
+        curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
+        // Do NOT set TCP_KEEPIDLE / TCP_KEEPINTVL
+
         std::string authValue;
         ApplyBasicAuth(curl, authValue);
 
@@ -263,12 +280,13 @@ namespace tin::network
         if (rc == CURLE_OK && httpCode == 206)
             return 0;
 
-        LOG_DEBUG("Range request failed url=%s range=%s http=%lu curl=%d\n",
-            requestUrl.c_str(), range.c_str(), httpCode, (int)rc);
+        LOG_DEBUG("Range request failed url=%s range=%s http=%lu curl=%d (%s)\n",
+            requestUrl.c_str(), range.c_str(), httpCode, (int)rc, curl_easy_strerror(rc));
 
         if (httpCode != 0 && httpCode != 206)
             return static_cast<int>(httpCode);
 
+        // e.g. CURLE_OPERATION_TIMEDOUT from LOW_SPEED → retriable in StreamDataRange
         return 1000 + static_cast<int>(rc);
     }
 
@@ -471,8 +489,8 @@ namespace tin::network
         if (!m_rangesSupported)
             THROW_FORMAT("Attempted range request when ranges aren't supported!\n");
 
-        static constexpr int kMaxRetries = 3;
-        static constexpr u64 kRetryDelayNs = 2000000000ULL;
+        static constexpr int kMaxRetries = 15;
+        static constexpr u64 kRetryDelayNs = 2500000000ULL;
 
         auto streamWithRetry = [&](const std::string& url, size_t requestOffset, size_t requestSize) -> int
         {


### PR DESCRIPTION
Improves reliability of large remote downloads (especially over Tailscale / reverse proxy / different ISP).

### Changes
- Faster stall detection (`LOW_SPEED_TIME` reduced to 15s)
- Force `CURLOPT_FRESH_CONNECT` + `CURLOPT_FORBID_REUSE` on range requests
- Silent auto-retry cycles in `http_nsp` before showing the UI prompt
- Increased max retries / reduced delay in `StreamDataRange`
- Bonus: Overclock now helps remote downloads go over the previous 5-6 MB/s cap

Related to #119