### PR TITLE
feat: add support for AeroFoil Cheat manager in remote

### DIFF
--- a/include/cheat_manager.hpp
+++ b/include/cheat_manager.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace inst::cheats {
+    struct LocalCheat {
+        std::string buildId;
+        std::string text;
+    };
+
+    // Identifiers are intentionally strict: they become components of an SD path.
+    bool IsValidTitleId(const std::string& titleId);
+    bool IsValidBuildId(const std::string& buildId);
+    std::string TargetPath(const std::string& titleId, const std::string& buildId);
+    bool IsInstalled(const std::string& titleId, const std::string& buildId);
+    bool Read(const std::string& titleId, const std::string& buildId, std::string& text, std::string& error);
+    bool WriteAtomically(const std::string& titleId, const std::string& buildId, const std::string& text, std::string& error);
+    bool Remove(const std::string& titleId, const std::string& buildId, std::string& error);
+    std::vector<LocalCheat> List(const std::string& titleId, std::string& error);
+}

--- a/include/remoteInstall.hpp
+++ b/include/remoteInstall.hpp
@@ -17,6 +17,9 @@ namespace remoteInstStuff {
         std::string saveId;
         std::string saveNote;
         std::string saveCreatedAt;
+        std::string cheatTitleId;
+        std::string cheatBuildId;
+        std::string cheatNote;
         std::uint64_t saveCreatedTs = 0;
         std::uint64_t size;
         std::uint64_t titleId = 0;
@@ -29,6 +32,7 @@ namespace remoteInstStuff {
         bool hasIconUrl = false;
         bool hasAppId = false;
         bool googleDriveWithoutApiKey = false;
+        bool isCheat = false;
     };
 
     struct RemoteSection {
@@ -41,5 +45,7 @@ namespace remoteInstStuff {
     std::vector<RemoteSection> FetchRemoteSections(const std::string& remoteUrl, const std::string& user, const std::string& pass, std::string& error, bool* outUsedLegacyFallback = nullptr, const RemoteFetchProgressCallback& progressCb = RemoteFetchProgressCallback());
     std::string FetchRemoteMotd(const std::string& remoteUrl, const std::string& user, const std::string& pass);
     std::string GetRemoteApiPrefix();
+    bool DownloadCheatText(const RemoteItem& item, const std::string& user, const std::string& pass, std::string& text, std::string& error);
+    bool UploadCheatText(const std::string& remoteUrl, const std::string& user, const std::string& pass, const std::string& titleId, const std::string& buildId, const std::string& note, const std::string& text, std::string& error);
     void installTitleRemote(const std::vector<RemoteItem>& items, int storage, const std::string& sourceLabel);
 }

--- a/include/ui/remoteInstPage.hpp
+++ b/include/ui/remoteInstPage.hpp
@@ -73,6 +73,7 @@ namespace inst::ui {
             bool saveSyncLoaded = false;
             bool pendingMotdFetch = false;
             bool suppressBottomHints = false;
+            bool cheatInstallProgressVisible = false;
             std::string activeRemoteUrl;
             bool catalogCacheValid = false;
             bool catalogCacheUsedLegacyFallback = false;
@@ -221,6 +222,8 @@ namespace inst::ui {
             bool isAllSection() const;
             bool isInstalledSection() const;
             bool isSaveSyncSection() const;
+            bool isCheatsSection() const;
+            bool isCheatCompatible(const remoteInstStuff::RemoteItem& item) const;
             void ensureSaveSyncSectionLoaded();
             void showInstalledDetails();
             void buildSaveSyncSection(const std::string& remoteUrl);
@@ -230,6 +233,10 @@ namespace inst::ui {
             void refreshSaveVersionSelectorDetailText();
             bool handleSaveVersionSelectorInput(u64 Down, u64 Up, u64 Held, pu::ui::Touch Pos);
             void handleSaveSyncAction(int selectedIndex);
+            void handleCheatAction(int selectedIndex);
+            void installAllCheats();
+            void showCheatInstallProgress();
+            void manageLocalCheats(const remoteInstStuff::RemoteItem& item);
             void showCurrentDescriptionDialog();
             bool tryGetCurrentDescription(std::string& outTitle, std::string& outDescription) const;
             void openDescriptionOverlay();

--- a/include/util/config.hpp
+++ b/include/util/config.hpp
@@ -45,6 +45,7 @@ namespace inst::config {
     extern bool usbAck;
     extern bool remoteHideInstalled;
     extern bool remoteHideInstalledSection;
+    extern bool remoteHideIncompatibleCheats;
     extern bool remoteAllBaseOnly;
     extern bool remoteLegacyMode;
     extern bool remoteStartGridMode;
@@ -78,4 +79,3 @@ namespace inst::config {
     void setConfig();
     void parseConfig();
 }
-

--- a/source/cheat_manager.cpp
+++ b/source/cheat_manager.cpp
@@ -1,0 +1,124 @@
+#include "cheat_manager.hpp"
+
+#include <cctype>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+
+namespace {
+    constexpr const char* kCheatRoot = "sdmc:/atmosphere/contents";
+
+    bool IsUpperHex(const std::string& value, std::size_t minLength, std::size_t maxLength)
+    {
+        if (value.size() < minLength || value.size() > maxLength)
+            return false;
+        for (unsigned char c : value) {
+            if (!std::isdigit(c) && !(c >= 'A' && c <= 'F'))
+                return false;
+        }
+        return true;
+    }
+}
+
+namespace inst::cheats {
+    bool IsValidTitleId(const std::string& titleId) { return IsUpperHex(titleId, 16, 16); }
+    bool IsValidBuildId(const std::string& buildId) { return IsUpperHex(buildId, 1, 64); }
+
+    std::string TargetPath(const std::string& titleId, const std::string& buildId)
+    {
+        if (!IsValidTitleId(titleId) || !IsValidBuildId(buildId))
+            return {};
+        return std::string(kCheatRoot) + "/" + titleId + "/cheats/" + buildId + ".txt";
+    }
+
+    bool IsInstalled(const std::string& titleId, const std::string& buildId)
+    {
+        const std::string path = TargetPath(titleId, buildId);
+        return !path.empty() && std::filesystem::is_regular_file(path);
+    }
+
+    bool Read(const std::string& titleId, const std::string& buildId, std::string& text, std::string& error)
+    {
+        text.clear(); error.clear();
+        const std::string path = TargetPath(titleId, buildId);
+        if (path.empty()) { error = "Invalid title ID or build ID."; return false; }
+        std::ifstream in(path, std::ios::binary);
+        if (!in) { error = "Cheat file is not installed."; return false; }
+        text.assign(std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>());
+        if (!in.good() && !in.eof()) { error = "Could not read cheat file."; return false; }
+        return true;
+    }
+
+    bool WriteAtomically(const std::string& titleId, const std::string& buildId, const std::string& text, std::string& error)
+    {
+        error.clear();
+        const std::string path = TargetPath(titleId, buildId);
+        if (path.empty()) { error = "Invalid title ID or build ID."; return false; }
+        const std::filesystem::path target(path);
+        std::error_code ec;
+        std::filesystem::create_directories(target.parent_path(), ec);
+        if (ec) { error = "Could not create Atmosphere cheat directory."; return false; }
+        const std::filesystem::path temporary = target.string() + ".tmp";
+        {
+            std::ofstream out(temporary, std::ios::binary | std::ios::trunc);
+            if (!out) { error = "Could not create temporary cheat file."; return false; }
+            out.write(text.data(), static_cast<std::streamsize>(text.size()));
+            out.flush();
+            if (!out) { error = "Could not write cheat text."; std::filesystem::remove(temporary, ec); return false; }
+        }
+        // FatFs rejects rename-over-an-existing-file. Move an existing file aside
+        // first, then restore it if promoting the complete temporary file fails.
+        const std::filesystem::path backup = target.string() + ".bak";
+        std::filesystem::remove(backup, ec); // stale backup from an interrupted older write
+        const bool replacing = std::filesystem::exists(target, ec);
+        if (ec) { std::filesystem::remove(temporary, ec); error = "Could not inspect existing cheat file."; return false; }
+        if (replacing && std::rename(target.string().c_str(), backup.string().c_str()) != 0) {
+            std::filesystem::remove(temporary, ec);
+            error = "Could not prepare existing cheat file for replacement.";
+            return false;
+        }
+        if (std::rename(temporary.string().c_str(), target.string().c_str()) != 0) {
+            if (replacing)
+                std::rename(backup.string().c_str(), target.string().c_str());
+            std::filesystem::remove(temporary, ec);
+            error = "Could not replace cheat file.";
+            return false;
+        }
+        if (replacing)
+            std::filesystem::remove(backup, ec);
+        return true;
+    }
+
+    bool Remove(const std::string& titleId, const std::string& buildId, std::string& error)
+    {
+        error.clear();
+        const std::string path = TargetPath(titleId, buildId);
+        if (path.empty()) { error = "Invalid title ID or build ID."; return false; }
+        std::error_code ec;
+        if (!std::filesystem::remove(path, ec)) {
+            error = ec ? "Could not delete cheat file." : "Cheat file is not installed.";
+            return false;
+        }
+        return true;
+    }
+
+    std::vector<LocalCheat> List(const std::string& titleId, std::string& error)
+    {
+        error.clear();
+        std::vector<LocalCheat> result;
+        if (!IsValidTitleId(titleId)) { error = "Invalid title ID."; return result; }
+        const std::filesystem::path dir = std::string(kCheatRoot) + "/" + titleId + "/cheats";
+        std::error_code ec;
+        if (!std::filesystem::exists(dir, ec)) return result;
+        for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+            if (ec) break;
+            if (!entry.is_regular_file() || entry.path().extension() != ".txt") continue;
+            const std::string buildId = entry.path().stem().string();
+            if (!IsValidBuildId(buildId)) continue;
+            std::string text, readError;
+            if (Read(titleId, buildId, text, readError)) result.push_back({buildId, std::move(text)});
+        }
+        if (ec) error = "Could not list local cheats.";
+        return result;
+    }
+}

--- a/source/remoteInstall.cpp
+++ b/source/remoteInstall.cpp
@@ -14,6 +14,7 @@
 #include <zstd.h>
 #include <mbedtls/aes.h>
 #include "remoteInstall.hpp"
+#include "cheat_manager.hpp"
 #include "install/http_nsp.hpp"
 #include "install/http_xci.hpp"
 #include "install/install.hpp"
@@ -1292,6 +1293,17 @@ namespace {
                             item.saveNote = entry["save_note"].get<std::string>();
                         else if (entry.contains("saveNote") && entry["saveNote"].is_string())
                             item.saveNote = entry["saveNote"].get<std::string>();
+                        // AeroFoil cheats are catalog entries, not installable content.
+                        const bool cheatSection = (parsed.id == "cheats");
+                        const bool cheatType = entry.contains("app_type") && entry["app_type"].is_string() && entry["app_type"].get<std::string>() == "CHEAT";
+                        if (cheatSection || cheatType) {
+                            item.cheatTitleId = entry.value("title_id", "");
+                            item.cheatBuildId = entry.value("build_id", "");
+                            item.cheatNote = entry.value("note", "");
+                            item.isCheat = inst::cheats::IsValidTitleId(item.cheatTitleId) && inst::cheats::IsValidBuildId(item.cheatBuildId);
+                            if (entry.contains("title_name") && entry["title_name"].is_string())
+                                item.name = entry["title_name"].get<std::string>() + " — " + item.cheatBuildId;
+                        }
                         if (entry.contains("created_at") && entry["created_at"].is_string())
                             item.saveCreatedAt = entry["created_at"].get<std::string>();
                         else if (entry.contains("createdAt") && entry["createdAt"].is_string())
@@ -1318,6 +1330,14 @@ namespace {
                     }
                 }
 
+                if (parsed.id == "cheats") {
+                    // Keep all builds for a title adjacent in the dedicated Cheats section.
+                    std::stable_sort(parsed.items.begin(), parsed.items.end(), [](const auto& a, const auto& b) {
+                        if (a.name != b.name)
+                            return inst::util::ignoreCaseCompare(a.name, b.name);
+                        return a.cheatBuildId < b.cheatBuildId;
+                    });
+                }
                 if (!parsed.items.empty())
                     sections.push_back(parsed);
             }
@@ -2213,6 +2233,71 @@ namespace remoteInstStuff {
         if (tryLegacyFallback())
             return sections;
         return sections;
+    }
+
+    bool DownloadCheatText(const RemoteItem& item, const std::string& user, const std::string& pass, std::string& text, std::string& error)
+    {
+        text.clear(); error.clear();
+        if (!item.isCheat || item.url.empty() || !inst::cheats::IsValidTitleId(item.cheatTitleId) || !inst::cheats::IsValidBuildId(item.cheatBuildId)) {
+            error = "Invalid cheat entry.";
+            return false;
+        }
+        FetchResult fetch = FetchRemoteResponse(item.url, user, pass);
+        if (!ValidateRemoteResponse(fetch, error))
+            return false;
+        if (fetch.responseCode == 404 || fetch.responseCode == 405) {
+            error = "This AeroFoil server does not support the cheat download API.";
+            return false;
+        }
+        if (fetch.responseCode < 200 || fetch.responseCode >= 300) {
+            error = "Cheat download failed (HTTP " + std::to_string(fetch.responseCode) + ").";
+            return false;
+        }
+        text = std::move(fetch.body);
+        return true;
+    }
+
+    bool UploadCheatText(const std::string& remoteUrl, const std::string& user, const std::string& pass, const std::string& titleId, const std::string& buildId, const std::string& note, const std::string& text, std::string& error)
+    {
+        error.clear();
+        if (user.empty() && pass.empty()) { error = "Cheat upload requires authenticated AeroFoil admin credentials."; return false; }
+        if (!inst::cheats::IsValidTitleId(titleId) || !inst::cheats::IsValidBuildId(buildId)) { error = "Invalid title ID or build ID."; return false; }
+        const std::string baseUrl = NormalizeRemoteUrl(remoteUrl);
+        if (baseUrl.empty()) { error = "Remote URL is empty."; return false; }
+        const std::string url = BuildFullUrl(baseUrl, "/api/cheats");
+        CURL* curl = curl_easy_init();
+        if (!curl) { error = "Failed to initialize curl."; return false; }
+        std::string response;
+        curl_mime* mime = curl_mime_init(curl);
+        auto addField = [&](const char* name, const std::string& value) { curl_mimepart* part = curl_mime_addpart(mime); curl_mime_name(part, name); curl_mime_data(part, value.data(), value.size()); };
+        addField("title_id", titleId); addField("build_id", buildId); addField("content", text);
+        if (!note.empty()) addField("note", note);
+        curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+        const std::string userAgent = inst::config::remoteLegacyMode ? std::string() : inst::curl::getDefaultUserAgent();
+        curl_easy_setopt(curl, CURLOPT_USERAGENT, userAgent.c_str());
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteToString);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, kRemoteRequestTimeoutMs);
+        curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, kRemoteConnectTimeoutMs);
+        curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
+        struct curl_slist* headerList = nullptr;
+        for (const auto& header : BuildLegacyHeaders(url, user, pass)) headerList = curl_slist_append(headerList, header.c_str());
+        if (headerList) curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headerList);
+        const std::string authValue = user + ":" + pass;
+        curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        curl_easy_setopt(curl, CURLOPT_USERPWD, authValue.c_str());
+        const CURLcode rc = curl_easy_perform(curl);
+        long responseCode = 0; curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
+        if (headerList) curl_slist_free_all(headerList);
+        curl_mime_free(mime); curl_easy_cleanup(curl);
+        if (rc != CURLE_OK) { error = curl_easy_strerror(rc); return false; }
+        if (responseCode == 401 || responseCode == 403) { error = "AeroFoil rejected the upload: this Remote account is not an admin."; return false; }
+        if (responseCode == 404 || responseCode == 405) { error = "This AeroFoil server does not support cheat uploads."; return false; }
+        if (responseCode < 200 || responseCode >= 300) { error = "Cheat upload failed (HTTP " + std::to_string(responseCode) + ")."; return false; }
+        try { const auto body = nlohmann::json::parse(response); if (body.contains("success") && body["success"].is_boolean() && !body["success"].get<bool>()) { error = body.value("error", "AeroFoil rejected the upload."); return false; } } catch (...) { /* Some AeroFoil versions return an empty success body. */ }
+        return true;
     }
 
     namespace {

--- a/source/ui/optionsPage.cpp
+++ b/source/ui/optionsPage.cpp
@@ -525,6 +525,7 @@ namespace inst::ui {
             addItem("Tinfoil Mode (legacy Remote compatibility)", true, inst::config::remoteLegacyMode);
             addItem("options.menu_items.remote_hide_installed"_lang, true, inst::config::remoteHideInstalled);
             addItem("options.menu_items.remote_hide_installed_section"_lang, true, inst::config::remoteHideInstalledSection);
+            addItem("Hide cheats not matching local build / installed title", true, inst::config::remoteHideIncompatibleCheats);
             addItem("options.menu_items.remote_all_base_only"_lang, true, inst::config::remoteAllBaseOnly);
             addItem("options.menu_items.remote_start_grid_mode"_lang, true, inst::config::remoteStartGridMode);
             addItem("Offline DB auto-check on startup", true, inst::config::offlineDbAutoCheckOnStartup);
@@ -1032,7 +1033,7 @@ namespace inst::ui {
                 if ((selectedIndex < 0) || (selectedIndex >= static_cast<int>(sizeof(kGeneralMap) / sizeof(kGeneralMap[0])))) return;
                 selectedIndex = kGeneralMap[selectedIndex];
             } else if (this->selectedSection == 1) {
-                static const int kRemoteMap[] = {20, 21, 25, 26, 12, 13, 24, 19, 23, 22};
+                static const int kRemoteMap[] = {20, 21, 25, 26, 12, 13, 27, 24, 19, 23, 22};
                 if ((selectedIndex < 0) || (selectedIndex >= static_cast<int>(sizeof(kRemoteMap) / sizeof(kRemoteMap[0])))) return;
                 selectedIndex = kRemoteMap[selectedIndex];
             } else {
@@ -1248,6 +1249,11 @@ namespace inst::ui {
                     break;
                 case 13:
                     inst::config::remoteHideInstalledSection = !inst::config::remoteHideInstalledSection;
+                    inst::config::setConfig();
+                    this->refreshOptions();
+                    break;
+                case 27:
+                    inst::config::remoteHideIncompatibleCheats = !inst::config::remoteHideIncompatibleCheats;
                     inst::config::setConfig();
                     this->refreshOptions();
                     break;

--- a/source/ui/remoteInstPage.cpp
+++ b/source/ui/remoteInstPage.cpp
@@ -16,6 +16,7 @@
 #include "ui/overflowText.hpp"
 #include "util/config.hpp"
 #include "util/curl.hpp"
+#include "cheat_manager.hpp"
 #include "util/lang.hpp"
 #include "util/offline_title_db.hpp"
 #include "util/save_sync.hpp"
@@ -1312,6 +1313,30 @@ namespace inst::ui {
         return id == "saves" || id == "save";
     }
 
+    bool remoteInstPage::isCheatsSection() const {
+        if (this->remoteSections.empty() || this->selectedSectionIndex < 0 || this->selectedSectionIndex >= (int)this->remoteSections.size())
+            return false;
+        return this->remoteSections[this->selectedSectionIndex].id == "cheats";
+    }
+
+    bool remoteInstPage::isCheatCompatible(const remoteInstStuff::RemoteItem& item) const {
+        if (!item.isCheat)
+            return false;
+        std::uint64_t titleId = 0;
+        if (!TryParseHexU64(item.cheatTitleId, titleId))
+            return false;
+        // Horizon's title metadata does not expose program build IDs. A local
+        // Atmosphere cheat is therefore the only reliable build-ID signal.
+        const auto titleIt = this->installedSnapshot.baseInstalled.find(titleId);
+        if (titleIt == this->installedSnapshot.baseInstalled.end() || !titleIt->second)
+            return false;
+        std::string localError;
+        const auto localCheats = inst::cheats::List(item.cheatTitleId, localError);
+        if (localCheats.empty())
+            return true; // No local build signal: keep the server candidate visible.
+        return inst::cheats::IsInstalled(item.cheatTitleId, item.cheatBuildId);
+    }
+
     const std::vector<remoteInstStuff::RemoteItem>& remoteInstPage::getCurrentItems() const {
         static const std::vector<remoteInstStuff::RemoteItem> empty;
         if (this->remoteSections.empty())
@@ -1515,8 +1540,9 @@ namespace inst::ui {
         this->loadingProgressText->SetVisible(visible);
         this->loadingBarBack->SetVisible(visible);
         this->loadingBarFill->SetVisible(visible);
-        this->loadingStagesBack->SetVisible(visible);
-        this->loadingStagesText->SetVisible(visible);
+        const bool showRemoteStages = visible && !this->cheatInstallProgressVisible;
+        this->loadingStagesBack->SetVisible(showRemoteStages);
+        this->loadingStagesText->SetVisible(showRemoteStages);
         if (!visible) {
             this->loadingStageIndex = -1;
             this->loadingSpinnerFrame = 0;
@@ -1689,6 +1715,10 @@ namespace inst::ui {
     std::string remoteInstPage::buildListMenuLabel(const remoteInstStuff::RemoteItem& item)
     {
         const std::string normalizedName = OverflowText::NormalizeSingleLineText(item.name);
+        if (item.isCheat) {
+            std::string suffix = inst::cheats::IsInstalled(item.cheatTitleId, item.cheatBuildId) ? " [Installed]" : " [Remote]";
+            return inst::util::shortenString(normalizedName, ComputeListNameLimit(suffix), true) + suffix;
+        }
         std::string sizeText = FormatSizeText(item.size);
         std::string suffix = sizeText.empty() ? "" : (" [" + sizeText + "]");
         const int nameLimit = ComputeListNameLimit(suffix);
@@ -1971,6 +2001,8 @@ namespace inst::ui {
         }
         else if (this->isSaveSyncSection())
             this->setButtonsText(" Manage Save     Refresh    / Section     Search    \xEE\x83\x85 Sort     Cancel");
+        else if (this->isCheatsSection())
+            this->setButtonsText(" Manage Cheat     Install All     Refresh    / Section     Search    \xEE\x83\x85 Sort     Cancel");
         else if (this->isInstalledSection())
             this->setButtonsText(" Details     Refresh    / Section     Search    \xEE\x83\x85 Sort     View     Cancel");
         else {
@@ -2904,7 +2936,7 @@ namespace inst::ui {
             for (auto& section : this->remoteSections) {
                 if (section.items.empty())
                     continue;
-                if (section.id == "all" || section.id == "installed")
+                if (section.id == "all" || section.id == "installed" || section.id == "cheats")
                     continue;
                 if (section.id == "updates" || section.id == "dlc")
                     continue;
@@ -2930,7 +2962,7 @@ namespace inst::ui {
             for (auto& section : this->remoteSections) {
                 if (section.items.empty())
                     continue;
-                if (section.id == "installed" || section.id == "updates" || section.id == "update" ||
+                if (section.id == "installed" || section.id == "updates" || section.id == "update" || section.id == "cheats" ||
                     (this->saveSyncEnabled && (section.id == "saves" || section.id == "save")))
                     continue;
 
@@ -3190,6 +3222,12 @@ namespace inst::ui {
             this->visibleItems = items;
         }
 
+        if (this->isCheatsSection() && inst::config::remoteHideIncompatibleCheats) {
+            this->visibleItems.erase(std::remove_if(this->visibleItems.begin(), this->visibleItems.end(), [&](const auto& item) {
+                return !this->isCheatCompatible(item);
+            }), this->visibleItems.end());
+        }
+
         if (this->isAllSection() && inst::config::remoteAllBaseOnly) {
             std::vector<remoteInstStuff::RemoteItem> baseOnlyItems;
             baseOnlyItems.reserve(this->visibleItems.size());
@@ -3203,6 +3241,7 @@ namespace inst::ui {
         if (!this->isAllSection())
             this->applyBrowseSort();
 
+
         if (!this->remoteSections.empty() && this->selectedSectionIndex >= 0 && this->selectedSectionIndex < static_cast<int>(this->remoteSections.size()) && this->visibleItems.empty()) {
             const auto &section = this->remoteSections[this->selectedSectionIndex];
             if (section.id == "updates" || section.id == "dlc") {
@@ -3212,6 +3251,11 @@ namespace inst::ui {
                 this->emptySectionText->SetVisible(true);
             } else if (section.id == "saves" || section.id == "save") {
                 this->emptySectionText->SetText("No saves available.");
+                CenterTextX(this->emptySectionText);
+                this->emptySectionText->SetY(350);
+                this->emptySectionText->SetVisible(true);
+            } else if (section.id == "cheats") {
+                this->emptySectionText->SetText("No cheats available from this AeroFoil server.");
                 CenterTextX(this->emptySectionText);
                 this->emptySectionText->SetY(350);
                 this->emptySectionText->SetVisible(true);
@@ -3255,8 +3299,9 @@ namespace inst::ui {
 
         const bool installedSection = this->isInstalledSection();
         const bool saveSyncSection = this->isSaveSyncSection();
+        const bool cheatsSection = this->isCheatsSection();
         std::unordered_set<std::string> selectedUrls;
-        if (!installedSection && !saveSyncSection && !this->selectedItems.empty()) {
+        if (!installedSection && !saveSyncSection && !cheatsSection && !this->selectedItems.empty()) {
             selectedUrls.reserve(this->selectedItems.size());
             for (const auto& selected : this->selectedItems) {
                 if (!selected.url.empty())
@@ -3277,7 +3322,7 @@ namespace inst::ui {
             }
             auto entry = pu::ui::elm::MenuItem::New(itm);
             entry->SetColor(COLOR("#FFFFFFFF"));
-            if (!installedSection && !saveSyncSection) {
+            if (!installedSection && !saveSyncSection && !cheatsSection) {
                 entry->SetIcon("romfs:/images/icons/checkbox-blank-outline.png");
                 if (!item.url.empty() && selectedUrls.find(item.url) != selectedUrls.end())
                     entry->SetIcon("romfs:/images/icons/check-box-outline.png");
@@ -3334,7 +3379,7 @@ namespace inst::ui {
     void remoteInstPage::refreshListSelectionIcons() {
         if (this->menu->GetItems().empty())
             return;
-        if (this->isInstalledSection() || this->isSaveSyncSection())
+        if (this->isInstalledSection() || this->isSaveSyncSection() || this->isCheatsSection())
             return;
 
         std::unordered_set<std::string> selectedUrls;
@@ -3906,7 +3951,14 @@ namespace inst::ui {
         );
         if (!error.empty()) {
             RemoteDlcTrace("FetchRemoteSections error: %s", error.c_str());
+            std::string audioPath = "romfs:/audio/bark.wav";
+            if (!inst::config::soundEnabled)
+                audioPath.clear();
+            else if (std::filesystem::exists(inst::config::appDir + "/bark.wav"))
+                audioPath = inst::config::appDir + "/bark.wav";
+            std::thread errorSound(inst::util::playAudio, audioPath);
             mainApp->CreateShowDialog("inst.remote.failed"_lang, error, {"common.ok"_lang}, true);
+            errorSound.join();
             mainApp->LoadLayout(mainApp->mainPage);
             return;
         }
@@ -4387,14 +4439,17 @@ namespace inst::ui {
         }
         if (this->remoteGridMode) {
             if (Down & HidNpadButton_Plus) {
-                if (!this->isInstalledSection() && !this->isSaveSyncSection() && !this->visibleItems.empty() && this->selectedItems.empty()) {
+                if (!this->isInstalledSection() && !this->isSaveSyncSection() && !this->isCheatsSection() && !this->visibleItems.empty() && this->selectedItems.empty()) {
                     this->selectTitle(this->remoteGridIndex);
                 }
-                if (!this->isInstalledSection() && !this->isSaveSyncSection() && !this->selectedItems.empty())
+                if (!this->isInstalledSection() && !this->isSaveSyncSection() && !this->isCheatsSection() && !this->selectedItems.empty())
                     this->startInstall();
             }
             if (Down & HidNpadButton_Y) {
-                if (!this->isInstalledSection() && !this->isSaveSyncSection()) {
+                if (this->isCheatsSection()) {
+                    this->installAllCheats();
+                    return;
+                } else if (!this->isInstalledSection() && !this->isSaveSyncSection()) {
                     if (this->selectedItems.size() == this->visibleItems.size()) {
                         this->selectedItems.clear();
                         this->updateRememberedSelection();
@@ -4520,6 +4575,8 @@ namespace inst::ui {
                         this->showInstalledDetails();
                     } else if (this->isSaveSyncSection()) {
                         this->handleSaveSyncAction(this->remoteGridIndex);
+                    } else if (this->isCheatsSection()) {
+                        this->handleCheatAction(this->remoteGridIndex);
                     } else {
                         this->selectTitle(this->remoteGridIndex);
                         if (this->visibleItems.size() == 1 && this->selectedItems.size() == 1) {
@@ -4594,6 +4651,8 @@ namespace inst::ui {
                         this->showInstalledDetails();
                     } else if (this->isSaveSyncSection()) {
                         this->handleSaveSyncAction(this->remoteGridIndex);
+                    } else if (this->isCheatsSection()) {
+                        this->handleCheatAction(this->remoteGridIndex);
                     } else {
                         this->selectTitle(this->remoteGridIndex);
                         if (this->visibleItems.size() == 1 && this->selectedItems.size() == 1) {
@@ -4612,6 +4671,8 @@ namespace inst::ui {
                 this->showInstalledDetails();
             } else if (this->isSaveSyncSection()) {
                 this->handleSaveSyncAction(this->menu->GetSelectedIndex());
+            } else if (this->isCheatsSection()) {
+                this->handleCheatAction(this->menu->GetSelectedIndex());
             } else {
                 this->selectTitle(this->menu->GetSelectedIndex());
                 if (this->menu->GetItems().size() == 1 && this->selectedItems.size() == 1) {
@@ -4651,7 +4712,10 @@ namespace inst::ui {
             this->openSearchDialog();
         }
         if (Down & HidNpadButton_Y) {
-            if (!this->isInstalledSection() && !this->isSaveSyncSection()) {
+            if (this->isCheatsSection()) {
+                this->installAllCheats();
+                return;
+            } else if (!this->isInstalledSection() && !this->isSaveSyncSection()) {
                 if (this->selectedItems.size() == this->menu->GetItems().size()) {
                     this->selectedItems.clear();
                     this->updateRememberedSelection();
@@ -4679,7 +4743,7 @@ namespace inst::ui {
             this->startRemote(true);
         }
         if (Down & HidNpadButton_Plus) {
-            if (!this->isInstalledSection() && !this->isSaveSyncSection()) {
+            if (!this->isInstalledSection() && !this->isSaveSyncSection() && !this->isCheatsSection()) {
                 if (this->selectedItems.empty()) {
                     this->selectTitle(this->menu->GetSelectedIndex());
                 }
@@ -4748,6 +4812,10 @@ namespace inst::ui {
                 if (!this->touchMoved && !this->menu->GetItems().empty()) {
                     if (this->isInstalledSection()) {
                         this->showInstalledDetails();
+                    } else if (this->isSaveSyncSection()) {
+                        this->handleSaveSyncAction(this->menu->GetSelectedIndex());
+                    } else if (this->isCheatsSection()) {
+                        this->handleCheatAction(this->menu->GetSelectedIndex());
                     } else {
                         this->selectTitle(this->menu->GetSelectedIndex());
                         if (this->menu->GetItems().size() == 1 && this->selectedItems.size() == 1) {
@@ -4858,6 +4926,148 @@ namespace inst::ui {
         }
 
         mainApp->CreateShowDialog(item.name, body, {"common.ok"_lang}, true);
+    }
+
+    void remoteInstPage::manageLocalCheats(const remoteInstStuff::RemoteItem& item)
+    {
+        std::string error;
+        const auto locals = inst::cheats::List(item.cheatTitleId, error);
+        if (!error.empty()) { mainApp->CreateShowDialog("Cheats", error, {"common.ok"_lang}, true); return; }
+        std::vector<std::string> choices;
+        for (const auto& local : locals) choices.push_back(local.buildId);
+        choices.push_back("Create or edit build ID...");
+        const int selected = mainApp->CreateShowDialog(item.name, "Local Atmosphere cheats for " + item.cheatTitleId, choices, false);
+        if (selected < 0) return;
+        std::string buildId = selected < (int)locals.size() ? locals[selected].buildId : inst::util::softwareKeyboard("Build ID (uppercase hex)", item.cheatBuildId, 64);
+        if (!inst::cheats::IsValidBuildId(buildId)) { mainApp->CreateShowDialog("Cheats", "Build ID must be uppercase hexadecimal.", {"common.ok"_lang}, true); return; }
+        std::string text;
+        inst::cheats::Read(item.cheatTitleId, buildId, text, error); // A new file intentionally starts empty.
+        const bool canAttemptAdminUpload = !inst::config::remoteUser.empty() || !inst::config::remotePass.empty();
+        std::vector<std::string> localActions = {"View", "Edit", "Delete"};
+        if (canAttemptAdminUpload)
+            localActions.push_back("Upload to AeroFoil");
+        localActions.push_back("common.cancel"_lang);
+        const int action = mainApp->CreateShowDialog("Local cheat " + buildId, "View, edit, delete, or upload this Atmosphere cheat.", localActions, false);
+        if (action == 0) { mainApp->CreateShowDialog("Cheat text", text.empty() ? "(empty)" : text, {"common.ok"_lang}, true); return; }
+        if (action == 1) {
+            const std::string edited = inst::util::softwareKeyboard("Cheat text (UTF-8)", text, 8192);
+            if (!inst::cheats::WriteAtomically(item.cheatTitleId, buildId, edited, error)) mainApp->CreateShowDialog("Cheats", error, {"common.ok"_lang}, true);
+            else mainApp->CreateShowDialog("Cheats", "Local cheat saved.", {"common.ok"_lang}, true);
+            return;
+        }
+        if (action == 2) {
+            if (mainApp->CreateShowDialog("Delete cheat?", buildId + ".txt will be removed from Atmosphere.", {"common.yes"_lang, "common.no"_lang}, false) == 0) {
+                if (!inst::cheats::Remove(item.cheatTitleId, buildId, error)) mainApp->CreateShowDialog("Cheats", error, {"common.ok"_lang}, true);
+                else mainApp->CreateShowDialog("Cheats", "Local cheat deleted.", {"common.ok"_lang}, true);
+            }
+            return;
+        }
+        if (canAttemptAdminUpload && action == 3) {
+            const std::string note = inst::util::softwareKeyboard("Server note (optional)", item.cheatNote, 120);
+            if (!remoteInstStuff::UploadCheatText(this->activeRemoteUrl, inst::config::remoteUser, inst::config::remotePass, item.cheatTitleId, buildId, note, text, error)) mainApp->CreateShowDialog("Cheats", error, {"common.ok"_lang}, true);
+            else mainApp->CreateShowDialog("Cheats", "Cheat uploaded to AeroFoil.", {"common.ok"_lang}, true);
+        }
+    }
+
+    void remoteInstPage::showCheatInstallProgress()
+    {
+        this->cheatInstallProgressVisible = true;
+        this->menu->SetVisible(false);
+        this->infoImage->SetVisible(false);
+        this->previewImage->SetVisible(false);
+        this->gridHighlight->SetVisible(false);
+        this->gridTitleText->SetVisible(false);
+        this->imageLoadingText->SetVisible(false);
+        this->listMarqueeMaskRect->SetVisible(false);
+        this->listMarqueeTintRect->SetVisible(false);
+        this->listMarqueeOverlayText->SetVisible(false);
+        this->listMarqueeClipEnabled = false;
+        this->listMarqueeFadeRect->SetVisible(false);
+        this->descriptionRect->SetVisible(false);
+        this->descriptionText->SetVisible(false);
+        for (auto& image : this->gridImages)
+            image->SetVisible(false);
+        for (auto& highlight : this->remoteGridSelectHighlights)
+            highlight->SetVisible(false);
+        for (auto& icon : this->remoteGridSelectIcons)
+            icon->SetVisible(false);
+    }
+
+    void remoteInstPage::installAllCheats()
+    {
+        std::vector<remoteInstStuff::RemoteItem> allCheats;
+        std::unordered_set<std::string> seenTargets;
+        for (const auto& section : this->remoteSections) {
+            if (section.id != "cheats") continue;
+            for (const auto& candidate : section.items) {
+                if (!candidate.isCheat) continue;
+                const std::string targetKey = candidate.cheatTitleId + "/" + candidate.cheatBuildId;
+                if (seenTargets.insert(targetKey).second)
+                    allCheats.push_back(candidate);
+            }
+        }
+        if (allCheats.empty()) { mainApp->CreateShowDialog("Cheats", "No valid cheats are available from this Remote.", {"common.ok"_lang}, true); return; }
+        if (mainApp->CreateShowDialog("Install all cheats?", "Install " + std::to_string(allCheats.size()) + " available cheat file(s) for all titles?", {"common.yes"_lang, "common.no"_lang}, false) != 0)
+            return;
+
+        this->showCheatInstallProgress();
+        int installedCount = 0;
+        std::string firstError;
+        for (std::size_t index = 0; index < allCheats.size(); ++index) {
+            const auto& candidate = allCheats[index];
+            const bool replacing = inst::cheats::IsInstalled(candidate.cheatTitleId, candidate.cheatBuildId);
+            this->setLoadingProgressStage(std::string(replacing ? "Replacing" : "Installing") + " cheat " + std::to_string(index + 1) + "/" + std::to_string(allCheats.size()) + ": " + candidate.name);
+            this->setLoadingProgress(static_cast<int>((index * 100) / allCheats.size()), true);
+            mainApp->CallForRender();
+
+            std::string text, installError;
+            if (remoteInstStuff::DownloadCheatText(candidate, inst::config::remoteUser, inst::config::remotePass, text, installError) &&
+                inst::cheats::WriteAtomically(candidate.cheatTitleId, candidate.cheatBuildId, text, installError)) {
+                installedCount++;
+            } else if (firstError.empty()) {
+                firstError = installError;
+            }
+        }
+        this->setLoadingProgressStage("Cheat installation complete.");
+        this->setLoadingProgress(100, true);
+        mainApp->CallForRender();
+        std::string result = "Installed " + std::to_string(installedCount) + " of " + std::to_string(allCheats.size()) + " available cheat file(s).";
+        if (!firstError.empty()) result += "\nFirst failure: " + firstError;
+        mainApp->CreateShowDialog("Cheats", result, {"common.ok"_lang}, true);
+        this->cheatInstallProgressVisible = false;
+        this->setLoadingProgress(0, false);
+        this->drawMenuItems(false);
+    }
+
+    void remoteInstPage::handleCheatAction(int selectedIndex)
+    {
+        if (selectedIndex < 0 || selectedIndex >= (int)this->visibleItems.size()) return;
+        const auto& item = this->visibleItems[selectedIndex];
+        if (!item.isCheat) { mainApp->CreateShowDialog("Cheats", "This server returned an invalid cheat entry.", {"common.ok"_lang}, true); return; }
+        const bool installed = inst::cheats::IsInstalled(item.cheatTitleId, item.cheatBuildId);
+        std::string details = "Title ID: " + item.cheatTitleId + "\nBuild ID: " + item.cheatBuildId + "\nInstalled: " + (installed ? "Yes" : "No");
+        if (!item.cheatNote.empty()) details += "\nNote: " + item.cheatNote;
+        const int action = mainApp->CreateShowDialog(item.name, details, {"Download / install", "Manage local cheats", "common.cancel"_lang}, false);
+        if (action == 1) { this->manageLocalCheats(item); return; }
+        if (action != 0) return;
+        const bool replacing = inst::cheats::IsInstalled(item.cheatTitleId, item.cheatBuildId);
+        this->showCheatInstallProgress();
+        this->setLoadingProgressStage(std::string(replacing ? "Replacing" : "Installing") + " cheat: " + item.name);
+        this->setLoadingProgress(0, true);
+        mainApp->CallForRender();
+        std::string text, error;
+        if (!remoteInstStuff::DownloadCheatText(item, inst::config::remoteUser, inst::config::remotePass, text, error)) { this->cheatInstallProgressVisible = false; this->setLoadingProgress(0, false); mainApp->CreateShowDialog("Cheats", error, {"common.ok"_lang}, true); this->drawMenuItems(false); return; }
+        this->setLoadingProgressStage(std::string(replacing ? "Replacing" : "Writing") + " cheat: " + item.name);
+        this->setLoadingProgress(75, true);
+        mainApp->CallForRender();
+        if (!inst::cheats::WriteAtomically(item.cheatTitleId, item.cheatBuildId, text, error)) { this->cheatInstallProgressVisible = false; this->setLoadingProgress(0, false); mainApp->CreateShowDialog("Cheats", error, {"common.ok"_lang}, true); this->drawMenuItems(false); return; }
+        this->setLoadingProgressStage("Cheat installation complete.");
+        this->setLoadingProgress(100, true);
+        mainApp->CallForRender();
+        mainApp->CreateShowDialog("Cheats", "Installed to atmosphere/contents/" + item.cheatTitleId + "/cheats/" + item.cheatBuildId + ".txt", {"common.ok"_lang}, true);
+        this->cheatInstallProgressVisible = false;
+        this->setLoadingProgress(0, false);
+        this->drawMenuItems(false);
     }
 
     bool remoteInstPage::tryGetCurrentDescription(std::string& outTitle, std::string& outDescription) const {

--- a/source/util/config.cpp
+++ b/source/util/config.cpp
@@ -31,6 +31,7 @@ namespace inst::config {
     bool validateNCAs;
     bool remoteHideInstalled;
     bool remoteHideInstalledSection;
+    bool remoteHideIncompatibleCheats;
     bool remoteAllBaseOnly;
     bool remoteLegacyMode;
     bool remoteStartGridMode;
@@ -770,6 +771,7 @@ namespace inst::config {
             {"httpUserAgent", httpUserAgent},
             {"remoteHideInstalled", remoteHideInstalled},
             {"remoteHideInstalledSection", remoteHideInstalledSection},
+            {"remoteHideIncompatibleCheats", remoteHideIncompatibleCheats},
             {"remoteAllBaseOnly", remoteAllBaseOnly},
             {"remoteLegacyMode", remoteLegacyMode},
             {"remoteStartGridMode", remoteStartGridMode},
@@ -804,6 +806,7 @@ namespace inst::config {
         httpUserAgent.clear();
         remoteHideInstalled = true;
         remoteHideInstalledSection = true;
+        remoteHideIncompatibleCheats = false;
         remoteAllBaseOnly = true;
         remoteLegacyMode = false;
         remoteStartGridMode = false;
@@ -840,6 +843,7 @@ namespace inst::config {
             if (j.contains("httpUserAgent")) httpUserAgent = j["httpUserAgent"].get<std::string>();
             if (j.contains("remoteHideInstalled")) remoteHideInstalled = j["remoteHideInstalled"].get<bool>();
             if (j.contains("remoteHideInstalledSection")) remoteHideInstalledSection = j["remoteHideInstalledSection"].get<bool>();
+            if (j.contains("remoteHideIncompatibleCheats")) remoteHideIncompatibleCheats = j["remoteHideIncompatibleCheats"].get<bool>();
             if (j.contains("remoteAllBaseOnly")) remoteAllBaseOnly = j["remoteAllBaseOnly"].get<bool>();
             if (j.contains("remoteLegacyMode")) remoteLegacyMode = j["remoteLegacyMode"].get<bool>();
             if (j.contains("remoteStartGridMode")) remoteStartGridMode = j["remoteStartGridMode"].get<bool>();
@@ -868,6 +872,7 @@ namespace inst::config {
                 "httpUserAgent",
                 "remoteHideInstalled",
                 "remoteHideInstalledSection",
+                "remoteHideIncompatibleCheats",
                 "remoteAllBaseOnly",
                 "remoteLegacyMode",
                 "remoteStartGridMode",
@@ -917,4 +922,3 @@ namespace inst::config {
             setConfig();
     }
 }
-


### PR DESCRIPTION
Added an AeroFoil-integrated Cheats section with authenticated downloads, local cheat management, bulk install, compatibility filtering, and admin uploads. Cheat files are safely written to Atmosphère paths with replacement support, while the UI provides install progress, feedback, and Remote error audio.